### PR TITLE
Remove unneeded SHA from conda recipe

### DIFF
--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
 
 source:
   git_url:  ../..
-  sha256: 43c98fb629bc2b877a3ad47ae41881fb14bcaf3dd587035d7bf8649cfdfe4413
 
 build:
   noarch: python
@@ -50,7 +49,7 @@ test:
 
 about:
   home: https://github.com/coiled/coiled-runtime
-  summary:  "Simple and fast way to get started with dask"
+  summary:  "Simple and fast way to get started with Dask"
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE


### PR DESCRIPTION
Based on the `dask` nightly conda build `meta.yaml` files, I don't think this SHA is needed (I'm also not sure where it came from originally). If CI passes here, let's remove it 