### PR TITLE
Update GitHub actions cancelling condition

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,7 +6,7 @@ on:
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
 concurrency:
-  group: conda-${{ github.head_ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This matches what's used over in `distributed` and, I think, might fix some of the GHA job cancellation issues were were seeing earlier (xref https://github.com/coiled/coiled-runtime/pull/19#discussion_r846298772) 

cc @ncclementi 

EDIT: See https://docs.github.com/en/github-ae@latest/actions/learn-github-actions/contexts#github-context for the difference between `github.head_ref` and `github.ref`