### PR TITLE
[WIP] Test against multiple runtimes

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
-            mamba install -c ./dist/conda coiled-runtime
+            mamba install -c ./dist/conda -c conda-forge coiled-runtime
           else
             mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   conda:
-    name: Build (and upload)
+    name: Build (and upload) - ${{ matrix.node-version }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     # Required shell entrypoint to have properly activated conda environments

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9"]
+        runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +39,8 @@ jobs:
       - name: Install dependencies
         run: conda install conda-build conda-verify jinja2 packaging pytest
 
-      - name: Build conda package
+      - name: Build coiled-runtime
+        if: ${{ matrix.runtime-version == 'latest' }}
         run: |
           conda build recipe \
                 --output-folder dist/conda \
@@ -46,7 +48,15 @@ jobs:
 
       - name: Install coiled-runtime
         run: |
-          conda install -c ./dist/conda coiled-runtime
+          if [[ ${{ matrix.runtime-version }} = 'latest' ]]
+          then
+            conda install -c ./dist/conda coiled-runtime
+          else
+            conda install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
+          fi
+
+      - name: Export environment
+        run: |
           # For debugging
           echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
           conda env export | grep -E -v '^prefix:.*$'
@@ -56,7 +66,7 @@ jobs:
 
       - name: Upload conda package
         if: |
-          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && matrix.runtime-version == 'latest' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         env:
           ANACONDA_API_TOKEN: ${{ secrets.COILED_UPLOAD_TOKEN }}
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   conda:
-    name: Build (and upload) - ${{ matrix.node-version }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
+    name: Build (and upload) - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     # Required shell entrypoint to have properly activated conda environments


### PR DESCRIPTION
This adds the logic necessary for us to run our existing CI builds against multiple `coiled-runtime` versions. This way we can make sure that any tests, benchmarks, etc. which are added here run against the `latest` `coiled-runtime` version (i.e. whatever is in the `main` branch of this repo) as well as all currently support `coiled-runtime` releases.