### PR TITLE
Test multiple runtimes

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -88,13 +88,13 @@ jobs:
           # Ensure we run additional tests when testing the latest coiled-runtime
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
-            export PYTEST_MARKERS="-m latest_runtime"
+            export EXTRA_OPTIONS="--run-latest"
             export COILED_SOFTWARE_NAME=${{ env.COILED_SOFTWARE_NAME }}
           else
-            export PYTEST_MARKERS=" "
+            export EXTRA_OPTIONS=" "
           fi
 
-          python -m pytest $PYTEST_MARKERS tests
+          python -m pytest $EXTRA_OPTIONS tests
 
       - name: Build coiled-runtime
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -70,7 +70,9 @@ jobs:
         if: ${{ matrix.runtime-version == 'latest' }}
         env:
           DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
-        run: coiled env create --name dask-engineering/coiled-runtime-pr-${{ matrix.os }}-${{ matrix.python-version }} --conda latest.yaml
+        run: |
+          export COILED_ENV_NAME=$(echo "dask-engineering/coiled-runtime-pr-${{ matrix.os }}-${{ matrix.python-version }}" | sed 's/\.//g' )
+          coiled env create --name $COILED_ENV_NAME --conda latest.yaml
 
       - name: Run tests
         env:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
-            mamba install -c ./dist/conda coiled-runtime
+            mamba install -c ./dist/conda -c conda-forge coiled-runtime
           else
             mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -64,8 +64,10 @@ jobs:
         env:
           DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
-          export COILED_ENV_NAME=$(echo "dask-engineering/coiled-runtime-pr-${{ matrix.os }}-${{ matrix.python-version }}" | sed 's/\.//g' )
-          coiled env create --name $COILED_ENV_NAME --conda latest.yaml
+          export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
+          coiled env create \
+            --name dask-engineering/coiled-runtime-pr-$GITHUB_REF_NAME-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED \
+            --conda latest.yaml
 
       - name: Run tests
         env:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
           export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-branch-$GITHUB_REF_NAME-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+          echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"
           echo COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME >> $GITHUB_ENV
           coiled env create --name $COILED_SOFTWARE_NAME --conda latest.yaml
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   conda:
-    name: Build (and upload)
+    name: Build (and upload) - ${{ matrix.node-version }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     # Required shell entrypoint to have properly activated conda environments

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -91,10 +91,10 @@ jobs:
       - name: Upload conda package
         # Only upload on a single CI build when pushing a tagged commit to `main`
         if: |
-          matrix.os == 'ubuntu-latest' && \
-          matrix.python-version == '3.9' && \
-          matrix.runtime-version == 'latest' && \
-          github.event_name == 'push' && \
+          matrix.os == 'ubuntu-latest' &&
+          matrix.python-version == '3.9' &&
+          matrix.runtime-version == 'latest' &&
+          github.event_name == 'push' &&
           startsWith(github.ref, 'refs/tags')
         env:
           ANACONDA_API_TOKEN: ${{ secrets.COILED_UPLOAD_TOKEN }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+    # types:
+    #   - opened
+    #   - synchronize
+    #   - reopened
+    #   # Trigger on `closed` so we can clean up Coiled software environments
+    #   # that were created specifically for pull requests
+    #   - closed
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
@@ -14,6 +21,7 @@ concurrency:
 jobs:
   conda:
     name: Build (and upload) - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
+    # if: ${{ github.event_name == 'push' }} || ${{ github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     # Required shell entrypoint to have properly activated conda environments
@@ -82,6 +90,9 @@ jobs:
           coiled env create --name $COILED_SOFTWARE_NAME --conda latest.yaml
 
       - name: Run tests
+        # Want to delete software environment in next step even if tests fail
+        continue-on-error: true
+        id: tests
         env:
             DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
@@ -95,6 +106,18 @@ jobs:
           fi
 
           python -m pytest $EXTRA_OPTIONS tests
+
+      - name: Remove Coiled software environment
+        if: ${{ matrix.runtime-version == 'latest' }}
+        env:
+            DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
+        run: |
+          export COILED_SOFTWARE_NAME=${{ env.COILED_SOFTWARE_NAME }}
+          coiled env delete $COILED_SOFTWARE_NAME
+          if [[ ${{ steps.tests.outcome }} != 'success' ]]
+          then
+            exit 1
+          fi
 
       - name: Build coiled-runtime
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -63,26 +63,33 @@ jobs:
         env:
           DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
+          # Coiled software environment names can't contain "." characters
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
 
+          # NOTE: We _should_ be able to use GITHUB_REF_NAME for both push and pull_request events
+          # but have to add the if/else below to work around https://github.com/github/docs/issues/15319
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-pr-$GITHUB_HEAD_REF-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_HEAD_REF-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
           else
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-push-main-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-main-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
           fi
 
           echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"
+          # Put COILED_SOFTWARE_NAME into $GITHUB_ENV so it can be used in subsequent workflow steps
           echo COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME >> $GITHUB_ENV
+
           coiled env create --name $COILED_SOFTWARE_NAME --conda latest.yaml
 
       - name: Run tests
         env:
             DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
+          # Ensure we run additional tests when testing the latest coiled-runtime
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
             export PYTEST_MARKERS="-m latest_runtime"
+            export COILED_SOFTWARE_NAME=${{ env.COILED_SOFTWARE_NAME }}
           else
             export PYTEST_MARKERS=" "
           fi

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9"]
+        runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +39,8 @@ jobs:
       - name: Install dependencies
         run: conda install conda-build conda-verify jinja2 packaging pytest
 
-      - name: Build conda package
+      - name: Build coiled-runtime
+        if: ${{ matrix.runtime-version == 'latest' }}
         run: |
           conda build recipe \
                 --output-folder dist/conda \
@@ -46,7 +48,15 @@ jobs:
 
       - name: Install coiled-runtime
         run: |
-          conda install -c ./dist/conda coiled-runtime
+          if [[ ${{ matrix.runtime-version }} = 'latest' ]]
+          then
+            conda install -c ./dist/conda coiled-runtime
+          else
+            conda install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
+          fi
+
+      - name: Export environment
+        run: |
           # For debugging
           echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
           conda env export | grep -E -v '^prefix:.*$'
@@ -56,7 +66,7 @@ jobs:
 
       - name: Upload conda package
         if: |
-          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && matrix.runtime-version == 'latest' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         env:
           ANACONDA_API_TOKEN: ${{ secrets.COILED_UPLOAD_TOKEN }}
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Install coiled-runtime
         run: |
+          # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
+          # Otherwise, just install directly from the coiled / conda-forge channel
+
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
             python ci/create_latest_runtime_meta.py
@@ -67,6 +70,9 @@ jobs:
         env:
           DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
+          # If testing the latest `coiled-runtime`, we need to build a Coiled software environment
+          # that can be used when running tests
+
           # Coiled software environment names can't contain "." characters
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
 
@@ -108,6 +114,7 @@ jobs:
         env:
             DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
+          # Clean up an Coiled software environments we created just for this CI build
           export COILED_SOFTWARE_NAME=${{ env.COILED_SOFTWARE_NAME }}
           coiled env delete $COILED_SOFTWARE_NAME
           if [[ ${{ steps.tests.outcome }} != 'success' ]]

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   conda:
-    name: Build (and upload) - ${{ matrix.node-version }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
+    name: Build (and upload) - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     # Required shell entrypoint to have properly activated conda environments

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -76,11 +76,9 @@ jobs:
           # Coiled software environment names can't contain "." characters
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
 
-          # NOTE: We _should_ be able to use GITHUB_REF_NAME for both push and pull_request events
-          # but have to add the if/else below to work around https://github.com/github/docs/issues/15319
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_HEAD_REF-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-${{ github.event.number }}-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
           else
             export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-main-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
           fi

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -65,14 +65,21 @@ jobs:
           DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
-          coiled env create \
-            --name dask-engineering/coiled-runtime-pr-$GITHUB_REF_NAME-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED \
-            --conda latest.yaml
+          export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-branch-$GITHUB_REF_NAME-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+          echo COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME >> $GITHUB_ENV
+          coiled env create --name $COILED_SOFTWARE_NAME --conda latest.yaml
 
       - name: Run tests
         env:
             DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
-        run: python -m pytest tests
+        run: |
+          if [[ ${{ matrix.runtime-version }} = 'latest' ]]
+          then
+            export PYTEST_MARKERS = "-m latest_runtime"
+          else
+            export PYTEST_MARKERS = ""
+          fi
+          python -m pytest $PYTEST_MARKERS tests
 
       - name: Build coiled-runtime
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -48,7 +48,6 @@ jobs:
           then
             python ci/create_latest_runtime_meta.py
             mamba install -c coiled -c conda-forge --file latest.txt
-            # mamba install -c ./dist/conda -c conda-forge coiled-runtime
           else
             mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi
@@ -65,7 +64,14 @@ jobs:
           DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
-          export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-branch-$GITHUB_REF_NAME-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+
+          if [[ ${{ github.event_name }} = 'pull_request' ]]
+          then
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-pr-$GITHUB_HEAD_REF-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+          else
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-push-main-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+          fi
+
           echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"
           echo COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME >> $GITHUB_ENV
           coiled env create --name $COILED_SOFTWARE_NAME --conda latest.yaml

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -75,10 +75,11 @@ jobs:
         run: |
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
-            export PYTEST_MARKERS = "-m latest_runtime"
+            export PYTEST_MARKERS="-m latest_runtime"
           else
-            export PYTEST_MARKERS = ""
+            export PYTEST_MARKERS=" "
           fi
+
           python -m pytest $PYTEST_MARKERS tests
 
       - name: Build coiled-runtime

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
-            python ci/create_latest_runtime_meta.py --output latest.txt
+            python ci/create_latest_runtime_meta.py
             mamba install -c coiled -c conda-forge --file latest.txt
             # mamba install -c ./dist/conda -c conda-forge coiled-runtime
           else
@@ -65,6 +65,12 @@ jobs:
           # For debugging
           echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
           mamba env export | grep -E -v '^prefix:.*$'
+
+      - name: Build Coiled software environment
+        if: ${{ matrix.runtime-version == 'latest' }}
+        env:
+          DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
+        run: coiled env create --name dask-engineering/coiled-runtime-pr-${{ matrix.os }}-${{ matrix.python-version }} --conda latest.yaml
 
       - name: Run tests
         env:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,13 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    # types:
-    #   - opened
-    #   - synchronize
-    #   - reopened
-    #   # Trigger on `closed` so we can clean up Coiled software environments
-    #   # that were created specifically for pull requests
-    #   - closed
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
@@ -21,7 +14,6 @@ concurrency:
 jobs:
   conda:
     name: Build (and upload) - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
-    # if: ${{ github.event_name == 'push' }} || ${{ github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     # Required shell entrypoint to have properly activated conda environments

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -42,18 +42,20 @@ jobs:
       - name: Install dependencies
         run: mamba install boa conda-verify jinja2 packaging pytest
 
-      - name: Build coiled-runtime
-        if: ${{ matrix.runtime-version == 'latest' }}
-        run: |
-          conda mambabuild recipe \
-                --output-folder dist/conda \
-                --no-anaconda-upload 
+      # - name: Build coiled-runtime
+      #   if: ${{ matrix.runtime-version == 'latest' }}
+      #   run: |
+      #     conda mambabuild recipe \
+      #           --output-folder dist/conda \
+      #           --no-anaconda-upload 
 
       - name: Install coiled-runtime
         run: |
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
-            mamba install -c ./dist/conda -c conda-forge coiled-runtime
+            python ci/create_latest_runtime_meta.py --output latest.txt
+            mamba install -c coiled -c conda-forge --file latest.txt
+            # mamba install -c ./dist/conda -c conda-forge coiled-runtime
           else
             mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -26,6 +26,10 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
+        exclude:
+          # FIXME: Building Coiled software environments is currently broken on Windows
+          - os: windows-latest
+            runtime-version: "latest"
     
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -80,9 +80,9 @@ jobs:
           # but have to add the if/else below to work around https://github.com/github/docs/issues/15319
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_HEAD_REF-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_HEAD_REF-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
           else
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-main-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-main-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
           fi
 
           echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -42,13 +42,6 @@ jobs:
       - name: Install dependencies
         run: mamba install boa conda-verify jinja2 packaging pytest
 
-      # - name: Build coiled-runtime
-      #   if: ${{ matrix.runtime-version == 'latest' }}
-      #   run: |
-      #     conda mambabuild recipe \
-      #           --output-folder dist/conda \
-      #           --no-anaconda-upload 
-
       - name: Install coiled-runtime
         run: |
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
@@ -79,9 +72,21 @@ jobs:
             DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: python -m pytest tests
 
+      - name: Build coiled-runtime
+        if: ${{ matrix.runtime-version == 'latest' }}
+        run: |
+          conda mambabuild recipe \
+                --output-folder dist/conda \
+                --no-anaconda-upload
+
       - name: Upload conda package
+        # Only upload on a single CI build when pushing a tagged commit to `main`
         if: |
-          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && matrix.runtime-version == 'latest' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+          matrix.os == 'ubuntu-latest' && \
+          matrix.python-version == '3.9' && \
+          matrix.runtime-version == 'latest' && \
+          github.event_name == 'push' && \
+          startsWith(github.ref, 'refs/tags')
         env:
           ANACONDA_API_TOKEN: ${{ secrets.COILED_UPLOAD_TOKEN }}
         run: |

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import sys
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -15,6 +16,13 @@ def main():
     template = env.get_template("meta.yaml")
     meta = yaml.safe_load(template.render())
     requirements = meta["requirements"]["run"]
+
+    # Ensure Python is pinned to X.Y.Z version currently being used
+    python_version = ".".join(map(str, tuple(sys.version_info)[:3]))
+    assert sum([req.startswith("python ") for req in requirements]) == 1
+    for idx, req in enumerate(requirements):
+        if req.startswith("python "):
+            requirements[idx] = f"python =={python_version}"
 
     # File compatible with `mamba install --file <...>`
     with open("latest.txt", "w") as f:

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -2,19 +2,11 @@ from __future__ import annotations
 
 import pathlib
 
-import click
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
-@click.command(context_settings={"ignore_unknown_options": True})
-@click.option(
-    "--output",
-    type=click.Path(dir_okay=False, writable=True, path_type=pathlib.Path),
-    required=True,
-    help="Output file",
-)
-def main(output):
+def main():
     """Get package version pins specified in `recipe/meta.yaml`"""
     env = Environment(
         loader=FileSystemLoader(pathlib.Path(__file__).parent.parent / "recipe"),
@@ -22,8 +14,17 @@ def main(output):
     )
     template = env.get_template("meta.yaml")
     meta = yaml.safe_load(template.render())
-    with open(output, "w") as f:
-        f.write("\n".join(meta["requirements"]["run"]))
+    requirements = meta["requirements"]["run"]
+
+    # File compatible with `mamba install --file <...>`
+    with open("latest.txt", "w") as f:
+        f.write("\n".join(requirements))
+
+    # File compatible with `mamba env create --file <...>`
+    env = {"channels": ["coiled", "conda-forge"]}
+    env["dependencies"] = requirements
+    with open("latest.yaml", "w") as f:
+        yaml.dump(env, f)
 
 
 if __name__ == "__main__":

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pathlib
+
+import click
+import yaml
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, writable=True, path_type=pathlib.Path),
+    required=True,
+    help="Output file",
+)
+def main(output):
+    """Get package version pins specified in `recipe/meta.yaml`"""
+    env = Environment(
+        loader=FileSystemLoader(pathlib.Path(__file__).parent.parent / "recipe"),
+        autoescape=select_autoescape(),
+    )
+    template = env.get_template("meta.yaml")
+    meta = yaml.safe_load(template.render())
+    with open(output, "w") as f:
+        f.write("\n".join(meta["requirements"]["run"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-latest", action="store_true", help="Run latest coiled-runtime tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-latest"):
+        # --run-latest given in cli: do not skip latest coiled-runtime tests
+        return
+    skip_latest = pytest.mark.skip(reason="need --run-latest option to run")
+    for item in items:
+        if "latest_runtime" in item.keywords:
+            item.add_marker(skip_latest)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 max-line-length = 120
 
 [tool:pytest]
-addopts = -v -rsxfE -m "not latest_runtime" --durations=10 --color=yes --strict-markers --strict-config
+addopts = -v -rsxfE --durations=10 --color=yes --strict-markers --strict-config
 markers =
     latest_runtime: marks tests that require the latest coiled-runtime

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,6 @@
 max-line-length = 120
 
 [tool:pytest]
-addopts = -v -rsxfE --durations=10 --color=yes
+addopts = -v -rsxfE -m "not latest_runtime" --durations=10 --color=yes --strict-markers --strict-config
+markers =
+    latest_runtime: marks tests that require the latest coiled-runtime

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,8 +8,6 @@ import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
 
-pytestmark = pytest.mark.latest_runtime
-
 
 def get_conda_installed_versions() -> dict[str, str]:
     """Get conda list packages in a list, and strip headers"""
@@ -40,6 +38,7 @@ def get_meta_specifiers() -> dict[str, SpecifierSet]:
     return meta_specifiers
 
 
+@pytest.mark.latest_runtime
 def test_install_dist():
     # Test that versions of packages installed are consistent with those
     # specified in `meta.yaml`

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import pathlib
 
 import conda.cli.python_api as Conda
+import pytest
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
+
+pytestmark = pytest.mark.latest_runtime
 
 
 def get_conda_installed_versions() -> dict[str, str]:

--- a/tests/test_coiled.py
+++ b/tests/test_coiled.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import uuid
 
@@ -6,7 +7,10 @@ import dask.dataframe as dd
 import pandas as pd
 from dask.distributed import Client
 
-SOFTWARE = f"dask-engineering/coiled_dist-py{sys.version_info[0]}{sys.version_info[1]}"
+SOFTWARE = os.environ.get(
+    "COILED_SOFTWARE_NAME",
+    f"dask-engineering/coiled_dist-py{sys.version_info[0]}{sys.version_info[1]}",
+)
 
 
 def test_quickstart():


### PR DESCRIPTION
This adds the logic necessary for us to run our existing CI builds against multiple coiled-runtime versions. This way we can make sure that any tests, benchmarks, etc. which are added here run against the latest coiled-runtime version (i.e. whatever is in the main branch of this repo) as well as all currently support coiled-runtime releases.

Supersedes https://github.com/coiled/coiled-runtime/pull/27