### PR TITLE
switch to v2 clusters (declarative)

### DIFF
--- a/tests/test_coiled.py
+++ b/tests/test_coiled.py
@@ -1,21 +1,20 @@
 import sys
 import uuid
 
-import coiled
 import dask.dataframe as dd
 import pandas as pd
+from coiled.v2 import Cluster
 from dask.distributed import Client
 
 SOFTWARE = f"dask-engineering/coiled_dist-py{sys.version_info[0]}{sys.version_info[1]}"
 
 
 def test_quickstart():
-    with coiled.Cluster(
+    with Cluster(
         software=SOFTWARE,
         name="nyc-quickstart_" + str(uuid.uuid4()),
         account="dask-engineering",
         n_workers=10,
-        backend_options={"spot": False},
     ) as cluster:
 
         with Client(cluster) as client:  # noqa F841


### PR DESCRIPTION
It would help out the clusters team if you can use v2 clusters -- those are the clusters under active development, so it's better to be dogfooding that.

This removes the `spot=False` b/c (1) that's the default anyway, and (2) v2 clusters don't support that argument quite yet.

Closes https://github.com/coiled/coiled-runtime/issues/35