### PR TITLE
[WIP] Add Python 3.7

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
         exclude:
           # FIXME: Building Coiled software environments is currently broken on Windows

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -30,6 +30,9 @@ jobs:
           # FIXME: Building Coiled software environments is currently broken on Windows
           - os: windows-latest
             runtime-version: "latest"
+          # TODO: This can be removed once there's a `coiled-runtime=0.0.3` build with `python>=3.7`
+          - python-version: "3.7"
+            runtime-version: "0.0.3"
     
     steps:
       - uses: actions/checkout@v2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.7
     - pip
 
   run:
-    - python >=3.8
+    - python >=3.7
     - pip
     - coiled
     - nodejs ==17.8.0


### PR DESCRIPTION
The currently pinned versions of `dask` / `distributed` support Python 3.7 and the latest `coiled` release also supports Python 3.7. Seeing what it would look like to add Python 3.7 to `coiled-runtime`

cc @ntabris 