### PR TITLE
Make sure when tests fail CI jobs always fail

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -105,7 +105,7 @@ jobs:
             export EXTRA_OPTIONS=" "
           fi
 
-          python -m pytest $EXTRA_OPTIONS tests
+          python -m pytest $EXTRA_OPTIONS tests/test_build.py::test_bad
 
       - name: Remove Coiled software environment
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run tests
         # Want to delete software environment in next step even if tests fail
-        continue-on-error: true
+        continue-on-error: ${{ matrix.runtime-version == 'latest' }}
         id: tests
         env:
             DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -105,7 +105,7 @@ jobs:
             export EXTRA_OPTIONS=" "
           fi
 
-          python -m pytest $EXTRA_OPTIONS tests/test_build.py::test_bad
+          python -m pytest $EXTRA_OPTIONS tests
 
       - name: Remove Coiled software environment
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -38,10 +38,6 @@ def get_meta_specifiers() -> dict[str, SpecifierSet]:
     return meta_specifiers
 
 
-def test_bad():
-    assert False
-
-
 @pytest.mark.latest_runtime
 def test_install_dist():
     # Test that versions of packages installed are consistent with those

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -38,6 +38,10 @@ def get_meta_specifiers() -> dict[str, SpecifierSet]:
     return meta_specifiers
 
 
+def test_bad():
+    assert False
+
+
 @pytest.mark.latest_runtime
 def test_install_dist():
     # Test that versions of packages installed are consistent with those


### PR DESCRIPTION
Currently we're setting `continue-on-error: true` for our testing step so we can make sure we delete any Coiled software environments we created as part of a push to `main` or a PR. However, since we only ever create Coiled software environments on the latest build, we should only set `continue-on-error: true` on latest builds. Otherwise, we end up with tests failing and a green check mark for the GHA build. 

Closes https://github.com/coiled/coiled-runtime/issues/42