### PR TITLE
Add Python 3.7

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
         exclude:
           # FIXME: Building Coiled software environments is currently broken on Windows

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -30,6 +30,9 @@ jobs:
           # FIXME: Building Coiled software environments is currently broken on Windows
           - os: windows-latest
             runtime-version: "latest"
+          # TODO: This can be removed once there's a `coiled-runtime=0.0.3` build with `python>=3.7`
+          - python-version: "3.7"
+            runtime-version: "0.0.3"
     
     steps:
       - uses: actions/checkout@v2

--- a/conftest.py
+++ b/conftest.py
@@ -2,9 +2,19 @@ import os
 import sys
 import uuid
 
+import coiled
 import pytest
-from coiled._beta import ClusterBeta as Cluster
 from dask.distributed import Client
+from packaging.version import Version
+
+# Use non-declarative clusters on Python 3.7 with `coiled <= 0.0.73`
+# See https://github.com/coiled/coiled-runtime/pull/54
+if tuple(sys.version_info[:2]) < (3, 8) and Version(coiled.__version__) <= Version(
+    "0.0.73"
+):
+    from coiled import Cluster
+else:
+    from coiled._beta import ClusterBeta as Cluster
 
 
 def pytest_addoption(parser):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.7
     - pip
 
   run:
-    - python >=3.8
+    - python >=3.7
     - pip
     - coiled
     - nodejs ==17.8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - nodejs ==17.8.0
     - nb_conda_kernels ==2.3.1
     - numpy ==1.21.5
-    - pandas ==1.4.1
+    - pandas ==1.3.5
     - dask ==2022.1.0
     - distributed ==2022.1.0
     - fsspec ==2022.3.0


### PR DESCRIPTION
The currently pinned versions of `dask` / `distributed` support Python 3.7 and the latest `coiled` release also supports Python 3.7. Seeing what it would look like to add Python 3.7 to `coiled-runtime`

cc @ntabris 