### PR TITLE
Solve with latest `coiled` release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - numba ==0.55.1
     - scikit-learn ==1.0.2
     - python-graphviz ==0.19.1
-    - click <=8.0.4
+    - click ==8.0.0
 
 test:
   imports:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import pathlib
 import shlex
 import subprocess
@@ -10,7 +11,7 @@ import pytest
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
-from packaging.version import InvalidVersion, Version
+from packaging.version import Version
 
 
 def get_conda_installed_versions() -> dict[str, str]:
@@ -62,14 +63,9 @@ def test_latest_coiled():
 
     # Get latest `coiled` release version from conda-forge
     output = subprocess.check_output(
-        shlex.split("conda search --override-channels -c conda-forge coiled")
+        shlex.split("conda search --override-channels --json -c conda-forge coiled")
     )
-    for i in output.decode().split("\n")[-2].split(" "):
-        try:
-            v_latest = Version(i)
-        except InvalidVersion:
-            continue
-        else:
-            break
+    result = json.loads(output)
+    v_latest = Version(result["coiled"][-1]["version"])
 
-    assert v_latest == v_installed
+    assert v_installed == v_latest


### PR DESCRIPTION
Updating this `click` pinning leads to me getting the latest `coiled==0.0.73` release when I build `coiled-runtime` locally and then attempt to install it. We need this `click` pin as `click=8.1.0` broke `distributed`. We've since included a fix in `distributed` itself (xref https://github.com/dask/distributed/pull/6018), but we can't use that version of `distributed` as it has known stability issues. 

TODO:

- [x] Add a test to make sure we always default to using the latest `coiled` release

Closes https://github.com/coiled/coiled-runtime/issues/22