### PR TITLE
Declarative clusters only 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,19 +2,9 @@ import os
 import sys
 import uuid
 
-import coiled
 import pytest
+from coiled.v2 import ClusterBeta as Cluster
 from dask.distributed import Client
-from packaging.version import Version
-
-# Use non-declarative clusters on Python 3.7 with `coiled <= 0.0.73`
-# See https://github.com/coiled/coiled-runtime/pull/54
-if tuple(sys.version_info[:2]) < (3, 8) and Version(coiled.__version__) <= Version(
-    "0.0.73"
-):
-    from coiled import Cluster
-else:
-    from coiled._beta import ClusterBeta as Cluster
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,12 @@ import sys
 import uuid
 
 import pytest
-from coiled.v2 import Cluster
+
+try:
+    from coiled.v2 import Cluster
+except ImportError:
+    from coiled._beta import ClusterBeta as Cluster
+
 from dask.distributed import Client
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@ import sys
 import uuid
 
 import pytest
-from coiled.v2 import ClusterBeta as Cluster
+from coiled.v2 import Cluster
 from dask.distributed import Client
 
 


### PR DESCRIPTION
I hadn't realized how frequently we'd run into errors with using non-declarative Coiled cluster (good job declarative team!). Now that we're pulling in the latest `coiled` by default, let's just switch back to only using new v2 clusters

xref https://github.com/coiled/coiled-runtime/issues/60

cc @dchudz 