### PR TITLE
Make Coiled software environment name more robust in CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -78,14 +78,15 @@ jobs:
           # If testing the latest `coiled-runtime`, we need to build a Coiled software environment
           # that can be used when running tests
 
-          # Coiled software environment names can't contain "." characters
+          # Coiled software environment names can't contain "." or uppercase characters
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
+          export OS_FORMATTED$(python -c "import os; print(os.environ['RUNNER_OS'].lower())")
 
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-${{ github.event.number }}-$GITHUB_RUN_ID-$RUNNER_OS-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-${{ github.event.number }}-$GITHUB_RUN_ID-$OS_FORMATTED-py$PYTHON_VERSION_FORMATTED
           else
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_REF_NAME-$GITHUB_RUN_ID-$RUNNER_OS-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_REF_NAME-$GITHUB_RUN_ID-$OS_FORMATTED-py$PYTHON_VERSION_FORMATTED
           fi
 
           echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -81,12 +81,15 @@ jobs:
           # Coiled software environment names can't contain "." or uppercase characters
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
           export OS_FORMATTED=$(python -c "import os; print(os.environ['RUNNER_OS'].lower())")
+          export REF_NAME_FORMATTED=$(echo "$GITHUB_REF_NAME" | sed 's/\./-/g' )
 
+          export COILED_SOFTWARE_NAME_HEAD=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME
+          export COILED_SOFTWARE_NAME_TAIL=$GITHUB_RUN_ID-$OS_FORMATTED-py$PYTHON_VERSION_FORMATTED
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-${{ github.event.number }}-$GITHUB_RUN_ID-$OS_FORMATTED-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME_HEAD-${{ github.event.number }}-$COILED_SOFTWARE_NAME_TAIL
           else
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_REF_NAME-$GITHUB_RUN_ID-$OS_FORMATTED-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME_HEAD-$GITHUB_REF_TYPE-$REF_NAME_FORMATTED-$COILED_SOFTWARE_NAME_TAIL
           fi
 
           echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -83,9 +83,9 @@ jobs:
 
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-${{ github.event.number }}-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-${{ github.event.number }}-$GITHUB_RUN_ID-$RUNNER_OS-py$PYTHON_VERSION_FORMATTED
           else
-            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-main-$GITHUB_SHA-${{ matrix.os }}-py$PYTHON_VERSION_FORMATTED
+            export COILED_SOFTWARE_NAME=dask-engineering/coiled-runtime-$GITHUB_EVENT_NAME-$GITHUB_REF_NAME-$GITHUB_RUN_ID-$RUNNER_OS-py$PYTHON_VERSION_FORMATTED
           fi
 
           echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -80,7 +80,7 @@ jobs:
 
           # Coiled software environment names can't contain "." or uppercase characters
           export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
-          export OS_FORMATTED$(python -c "import os; print(os.environ['RUNNER_OS'].lower())")
+          export OS_FORMATTED=$(python -c "import os; print(os.environ['RUNNER_OS'].lower())")
 
           if [[ ${{ github.event_name }} = 'pull_request' ]]
           then


### PR DESCRIPTION
We want the software environment to be different for pushes. This PR also makes the names a bit more compact

Closes https://github.com/coiled/coiled-runtime/issues/63