### PR TITLE
Larger dataframe shuffle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,6 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
-        exclude:
-          # FIXME: Building Coiled software environments is currently broken on Windows
-          - os: windows-latest
-            runtime-version: "latest"
     
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # NOTE(sjperkins): Revert testing matrix on completion of review
-        os: ["ubuntu-latest"]
-        python-version: ["3.9"]
-        runtime-version: ["latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
+        runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -110,8 +109,7 @@ jobs:
             export EXTRA_OPTIONS=" "
           fi
 
-          # NOTE(sjperkins): Remove specific test_shuffle.py on completion of review
-          python -m pytest -s -vvv $EXTRA_OPTIONS tests/test_shuffle.py
+          python -m pytest $EXTRA_OPTIONS tests
 
       - name: Remove Coiled software environment
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,8 @@ requirements:
     - nb_conda_kernels ==2.3.1
     - numpy ==1.21.5
     - pandas ==1.3.5
-    # TODO: Revert before merging
-    - dask ==2022.4.1
-    - distributed ==2022.4.1
-    # - dask ==2022.1.0
-    # - distributed ==2022.1.0
+    - dask ==2022.1.0
+    - distributed ==2022.1.0
     - fsspec ==2022.3.0
     - s3fs ==2022.3.0
     - gcsfs ==2022.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,11 @@ requirements:
     - nb_conda_kernels ==2.3.1
     - numpy ==1.21.5
     - pandas ==1.3.5
-    - dask ==2022.1.0
-    - distributed ==2022.1.0
+    # TODO: Revert before merging
+    - dask ==2022.4.1
+    - distributed ==2022.4.1
+    # - dask ==2022.1.0
+    # - distributed ==2022.1.0
     - fsspec ==2022.3.0
     - s3fs ==2022.3.0
     - gcsfs ==2022.3.0

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -32,7 +32,4 @@ def test_shuffle_parquet(small_client, s3_url, s3_storage_options):
     shuffled_url = s3_url + "/shuffled.parquet"
     df_shuffled = dd.read_parquet(dataset_url, storage_options=s3_storage_options)
     df_shuffled = df_shuffled.shuffle(on="x")
-    out = df_shuffled.to_parquet(
-        shuffled_url, compute=False, storage_options=s3_storage_options
-    )
-    dask.compute(out)
+    df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -32,4 +32,7 @@ def test_shuffle_parquet(small_client, s3_url, s3_storage_options):
     shuffled_url = s3_url + "/shuffled.parquet"
     df_shuffled = dd.read_parquet(dataset_url, storage_options=s3_storage_options)
     df_shuffled = df_shuffled.shuffle(on="x")
-    df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)
+    out = df_shuffled.to_parquet(
+        shuffled_url, compute=False, storage_options=s3_storage_options
+    )
+    dask.compute(out)

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -16,9 +16,7 @@ def test_shuffle_simple(small_client):
 
 
 @pytest.mark.stability
-def test_shuffle_parquet(small_client, s3_url_factory, s3_storage_options):
-    s3_url = s3_url_factory("shuffle-test-output")
-
+def test_shuffle_parquet(small_client, s3_url, s3_storage_options):
     # Write synthetic dataset to S3
     # Notes on how `freq` impacts total dataset size:
     #   - 100ms ~12GB
@@ -34,4 +32,7 @@ def test_shuffle_parquet(small_client, s3_url_factory, s3_storage_options):
     shuffled_url = s3_url + "/shuffled.parquet"
     df_shuffled = dd.read_parquet(dataset_url, storage_options=s3_storage_options)
     df_shuffled = df_shuffled.shuffle(on="x")
-    df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)
+    out = df_shuffled.to_parquet(
+        shuffled_url, compute=False, storage_options=s3_storage_options
+    )
+    dask.compute(out)

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -32,4 +32,9 @@ def test_shuffle_parquet(small_client, s3_url, s3_storage_options):
     shuffled_url = s3_url + "/shuffled.parquet"
     df_shuffled = dd.read_parquet(dataset_url, storage_options=s3_storage_options)
     df_shuffled = df_shuffled.shuffle(on="x")
-    df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)
+    # FIXME: Setting `compute=True` below causes the `to_parquet` call
+    # to take much, much longer. This is unexpected and we should fix this upstream.
+    result = df_shuffled.to_parquet(
+        shuffled_url, compute=False, storage_options=s3_storage_options
+    )
+    dask.compute(result)

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -5,8 +5,11 @@ import pytest
 
 @pytest.mark.stability
 def test_shuffle_simple(small_client, s3_url_factory, s3_storage_options):
-    write_url = s3_url_factory("shuffle-test-output")
-    test_url = s3_url_factory("shuffle-test-data")
+    s3_url = s3_url_factory("shuffle-test-output")
+    write_url = s3_url + "/shuffled.parquet"
+    test_url = s3_url + "/dataset.parquet"
+    # write_url = s3_url_factory("shuffle-test-output")
+    # test_url = s3_url_factory("shuffle-test-data")
 
     # 100ms ~12GB
     # 75ms ~15GB


### PR DESCRIPTION
Increase dataframe size to ~80GB. Introduce:

1. Read Operations
2. Shuffle
3. Write operations

Prior to this, it would be nice to able to write the ~80GB to some temporary AWS location that gets cleaned up once the tests complete. The written data should also be cleaned up after the tests complete.