### PR TITLE
Unskip Windows CI builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,6 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
-        exclude:
-          # FIXME: Building Coiled software environments is currently broken on Windows
-          - os: windows-latest
-            runtime-version: "latest"
     
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
These builds should hopefully pass now after https://github.com/conda-forge/coiled-feedstock/pull/89

cc @ncclementi 

Closes https://github.com/coiled/coiled-runtime/issues/49