### PR TITLE
Drop `coiled` conda channel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.9"]
-        runtime-version: ["0.0.3"]
-        # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        # python-version: ["3.7", "3.8", "3.9"]
-        # runtime-version: ["latest", "0.0.3"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
+        runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -113,7 +110,7 @@ jobs:
             export EXTRA_OPTIONS=" "
           fi
 
-          python -m pytest $EXTRA_OPTIONS tests/test_coiled.py::test_quickstart
+          python -m pytest $EXTRA_OPTIONS tests
 
       - name: Remove Coiled software environment
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
-        runtime-version: ["latest", "0.0.3"]
+        os: ["ubuntu-latest"]
+        python-version: ["3.9"]
+        runtime-version: ["0.0.3"]
+        # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # python-version: ["3.7", "3.8", "3.9"]
+        # runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -110,7 +113,7 @@ jobs:
             export EXTRA_OPTIONS=" "
           fi
 
-          python -m pytest $EXTRA_OPTIONS tests
+          python -m pytest $EXTRA_OPTIONS tests/test_coiled.py::test_quickstart
 
       - name: Remove Coiled software environment
         if: ${{ matrix.runtime-version == 'latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,9 @@ jobs:
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
             python ci/create_latest_runtime_meta.py
-            mamba install -c coiled -c conda-forge --file latest.txt
+            mamba install -c conda-forge --file latest.txt
           else
-            mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
+            mamba install -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi
 
       - name: Export environment

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Coiled Runtime is a conda metapackage which makes it easy to get started wit
 `coiled-runtime` can be installed with:
 
 ```bash
-conda install -c coiled -c conda-forge coiled-runtime
+conda install -c conda-forge coiled-runtime
 ```
 
 ## Build

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -29,7 +29,7 @@ def main():
         f.write("\n".join(requirements))
 
     # File compatible with `mamba env create --file <...>`
-    env = {"channels": ["coiled", "conda-forge"]}
+    env = {"channels": ["conda-forge"]}
     env["dependencies"] = requirements
     with open("latest.yaml", "w") as f:
         yaml.dump(env, f)

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import shlex
 import subprocess
@@ -7,13 +8,16 @@ import uuid
 
 import pytest
 import s3fs
+from dask.distributed import Client
 
 try:
     from coiled.v2 import Cluster
 except ImportError:
     from coiled._beta import ClusterBeta as Cluster
 
-from dask.distributed import Client
+
+# So coiled logs can be displayed on test failure
+logging.getLogger("coiled").setLevel(logging.INFO)
 
 
 def pytest_addoption(parser):

--- a/environments/coiled-runtime-0-0-3-py37.yml
+++ b/environments/coiled-runtime-0-0-3-py37.yml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
-  - coiled
 dependencies:
     - python=3.7
     - coiled-runtime=0.0.3

--- a/environments/coiled-runtime-0-0-3-py38.yml
+++ b/environments/coiled-runtime-0-0-3-py38.yml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
-  - coiled
 dependencies:
     - python=3.8
     - coiled-runtime=0.0.3

--- a/environments/coiled-runtime-0-0-3-py39.yml
+++ b/environments/coiled-runtime-0-0-3-py39.yml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
-  - coiled
 dependencies:
     - python=3.9
     - coiled-runtime=0.0.3

--- a/tests/test_coiled.py
+++ b/tests/test_coiled.py
@@ -19,3 +19,4 @@ def test_quickstart(small_client):
 
     assert isinstance(result, pd.Series)
     assert not result.empty
+    assert False

--- a/tests/test_coiled.py
+++ b/tests/test_coiled.py
@@ -19,4 +19,3 @@ def test_quickstart(small_client):
 
     assert isinstance(result, pd.Series)
     assert not result.empty
-    assert False


### PR DESCRIPTION
Since `coiled-runtime` is on `conda-forge` now, we no longer need to specify `-c coiled`