### PR TITLE
Update release procedure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,28 +125,6 @@ jobs:
             python -c "raise Exception('Tests failed. Please see the output from the previous step for more details.')"
           fi
 
-      - name: Build coiled-runtime
-        if: ${{ matrix.runtime-version == 'latest' }}
-        run: |
-          conda mambabuild recipe \
-                --output-folder dist/conda \
-                --no-anaconda-upload
-
-      - name: Upload conda package
-        # Only upload on a single CI build when pushing a tagged commit to `main`
-        if: |
-          matrix.os == 'ubuntu-latest'
-          && matrix.python-version == '3.9'
-          && matrix.runtime-version == 'latest'
-          && github.event_name == 'push'
-          && startsWith(github.ref, 'refs/tags')
-        env:
-          ANACONDA_API_TOKEN: ${{ secrets.COILED_UPLOAD_TOKEN }}
-        run: |
-          # install anaconda for upload
-          mamba install anaconda-client
-          anaconda upload dist/conda/noarch/*.tar.bz2
-
   report:
     name: report
     needs: tests

--- a/README.md
+++ b/README.md
@@ -33,19 +33,37 @@ conda install -c conda-forge -c ./dist/conda/ coiled-runtime
 
 ## Release
 
-To issue a new `coiled-runtime` release, update the `coiled-runtime` version specified in `meta.yaml`, then:
+To issue a new `coiled-runtime` release:
+
+1. Locally update the `coiled-runtime` version and package pinnings specified in `recipe/meta.yaml`.
+    - When updating package version pinnings (in particular `dask` and `distributed`)
+      confirm there are no reported large scale stability issues (e.g. deadlocks) or
+      performance regressions on the `dask` / `distributed` issue trackers or offline
+      reports.
+2. Open a pull request to the `coiled-runtime` repository titled "Release X.Y.Z" with these changes
+   (where `X.Y.Z` is replaced with the actual version for the release).
+3. After all CI builds have passed the release pull request can be merged.
+4. Add a new git tag for the release by following the steps below on your local machine:
 
 ```bash
-# Set next version number (matching version on `meta.yml`)
-export RELEASE=x.x.x
+# Pull in changes from the Release X.Y.Z PR
+git checkout main
+git pull origin main
 
-# Create tags
-git commit -m "Release $RELEASE"
+# Set release version number
+export RELEASE=X.Y.Z
+# Create and push release tag
 git tag -a $RELEASE -m "Version $RELEASE"
-
-# Push
-git push upstream main --tags
+git push origin main --tags
 ```
+
+5. Update the `coiled-runtime` package on conda-forge by opening a pull request to the
+   [`coiled-runtime` conda-forge feedstock](https://github.com/conda-forge/coiled-runtime-feedstock)
+   which updates the `coiled-runtime` version and package version pinnings.
+    - Note that pull requests to conda-forge feedstocks must come from a fork.
+    - Reset the build number back to `0` if it isn't already.
+    - For more information on updating conda-forge packages, see the
+      [conda-forge docs](https://conda-forge.org/docs/maintainer/updating_pkgs.html).
 
 ## License
 


### PR DESCRIPTION
This PR updates our release procedure to reflect that we're now issuing releases on conda-forge (instead of the `coiled` conda channel) as well as adds a few more details. 

cc @ncclementi @fjetter @hayesgb 