### PR TITLE
Test against development version of `dask` and `distributed`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,11 @@
 name: Tests
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
-  pull_request:
+on: [push]
+  # push:
+  #   branches:
+  #     - main
+  #   tags:
+  #     - '*'
+  # pull_request:
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
@@ -25,9 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        os: ["ubuntu-latest"]
+        python-version: ["3.9"]
         runtime-version: ["latest", "0.0.3"]
+        # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # python-version: ["3.7", "3.8", "3.9"]
+        # runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -49,10 +52,18 @@ jobs:
           # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
           # Otherwise, just install directly from the coiled / conda-forge channel
 
+          export TEST_UPSTREAM=""
+          echo "Commit message is..."
+          echo "${{ github.event.head_commit.message }}"
+          if [[ ${{ github.event.head_commit.message }} == *"test-upstream"* ]]; then
+            export TEST_UPSTREAM="true"
+            echo "Installed development version of dask and distributed"
+          fi
+
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
             python ci/create_latest_runtime_meta.py
-            mamba install -c coiled -c conda-forge --file latest.txt
+            mamba env update -c coiled -c conda-forge --file latest.yaml
           else
             mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest", "0.0.3"]
+        runtime-version: ["latest"]
         # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         # python-version: ["3.7", "3.8", "3.9"]
         # runtime-version: ["latest", "0.0.3"]
@@ -52,10 +52,10 @@ jobs:
           # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
           # Otherwise, just install directly from the coiled / conda-forge channel
 
-          export TEST_UPSTREAM=""
           echo "Commit message is..."
           echo "${{ github.event.head_commit.message }}"
-          if [[ ${{ github.event.head_commit.message }} == *"test-upstream"* ]]; then
+          if [[ ${{ github.event.head_commit.message }} == *"test-upstream"* ]]
+          then
             export TEST_UPSTREAM="true"
             echo "Installed development version of dask and distributed"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest"]
+        runtime-version: ["latest", "0.0.3"]
         # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         # python-version: ["3.7", "3.8", "3.9"]
         # runtime-version: ["latest", "0.0.3"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,8 @@ jobs:
           fi
 
       - name: Install coiled-runtime
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
           # Otherwise, just install directly from the coiled / conda-forge channel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,17 +44,22 @@ jobs:
       - name: Install dependencies
         run: mamba install boa conda-verify jinja2 packaging pytest
 
-      - name: Install coiled-runtime
+      - name: Check upstream
+        if: github.event_name == 'pull_request' && matrix.runtime-version == 'latest'
         run: |
-          # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
-          # Otherwise, just install directly from the coiled / conda-forge channel
-
           COMMIT="${{ github.event.head_commit.message }}"
           if [[ "$COMMIT" == *"test-upstream"* ]]
           then
             export TEST_UPSTREAM="true"
+            # Put TEST_UPSTREAM into $GITHUB_ENV so it can be used in subsequent workflow steps
+            echo TEST_UPSTREAM=$TEST_UPSTREAM >> $GITHUB_ENV
+            echo "Using development version of dask and distributed"
           fi
 
+      - name: Install coiled-runtime
+        run: |
+          # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
+          # Otherwise, just install directly from the coiled / conda-forge channel
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
             python ci/create_latest_runtime_meta.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,7 @@ jobs:
           # If testing the latest `coiled-runtime` then install packages defined in `recipe/meta.yaml`
           # Otherwise, just install directly from the coiled / conda-forge channel
 
-          echo "Commit message is..."
-          echo "${{ github.event.head_commit.message }}"
           COMMIT="${{ github.event.head_commit.message }}"
-          echo "commit is $COMMIT"
           if [[ "$COMMIT" == *"test-upstream"* ]]
           then
             export TEST_UPSTREAM="true"
@@ -65,7 +62,7 @@ jobs:
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
           then
             python ci/create_latest_runtime_meta.py
-            mamba env update -c coiled -c conda-forge --file latest.yaml
+            mamba env update --file latest.yaml
           else
             mamba install -c coiled -c conda-forge coiled-runtime=${{ matrix.runtime-version }}
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,9 @@ jobs:
 
           echo "Commit message is..."
           echo "${{ github.event.head_commit.message }}"
-          if [[ ${{ github.event.head_commit.message }} == *"test-upstream"* ]]
+          COMMIT="${{ github.event.head_commit.message }}"
+          echo "commit is $COMMIT"
+          if [[ "$COMMIT" == *"test-upstream"* ]]
           then
             export TEST_UPSTREAM="true"
             echo "Installed development version of dask and distributed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.9"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
-        # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        # python-version: ["3.7", "3.8", "3.9"]
-        # runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,11 @@
 name: Tests
-on: [push]
-  # push:
-  #   branches:
-  #     - main
-  #   tags:
-  #     - '*'
-  # pull_request:
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
@@ -25,12 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.9"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
         runtime-version: ["latest", "0.0.3"]
-        # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        # python-version: ["3.7", "3.8", "3.9"]
-        # runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +53,6 @@ jobs:
           if [[ "$COMMIT" == *"test-upstream"* ]]
           then
             export TEST_UPSTREAM="true"
-            echo "Installed development version of dask and distributed"
           fi
 
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        os: ["ubuntu-latest"]
+        python-version: ["3.9"]
         runtime-version: ["latest", "0.0.3"]
+        # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        # python-version: ["3.7", "3.8", "3.9"]
+        # runtime-version: ["latest", "0.0.3"]
     
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +50,7 @@ jobs:
       - name: Check upstream
         if: github.event_name == 'pull_request' && matrix.runtime-version == 'latest'
         run: |
-          COMMIT="${{ github.event.head_commit.message }}"
+          COMMIT="$(git log -n 1 --pretty=format:%s HEAD^2)"
           if [[ "$COMMIT" == *"test-upstream"* ]]
           then
             export TEST_UPSTREAM="true"

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -4,7 +4,7 @@ import json
 import os
 import pathlib
 import sys
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -12,9 +12,13 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 def get_latest_commit(repository):
     org, repo = repository.split("/")
-    response = urlopen(
-        f"https://api.github.com/repos/{org}/{repo}/commits?per_page=1"
-    ).read()
+    headers = {}
+    if os.environ.get("GITHUB_TOKEN", False):
+        headers = {"Authorization": f"token {os.environ['GITHUB_TOKEN']}"}
+    request = Request(
+        f"https://api.github.com/repos/{org}/{repo}/commits?per_page=1", headers=headers
+    )
+    response = urlopen(request).read()
     data = json.loads(response.decode())
     return data[0]["sha"]
 

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -12,8 +12,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 def get_latest_commit(repository):
     org, repo = repository.split("/")
-    url = f"https://api.github.com/repos/{org}/{repo}/commits?per_page=1"
-    response = urlopen(url).read()
+    response = urlopen(
+        f"https://api.github.com/repos/{org}/{repo}/commits?per_page=1"
+    ).read()
     data = json.loads(response.decode())
     return data[0]["sha"]
 
@@ -31,7 +32,6 @@ def main():
     # Ensure Python is pinned to X.Y.Z version currently being used
     python_version = ".".join(map(str, tuple(sys.version_info)[:3]))
     assert sum([req.startswith("python ") for req in requirements]) == 1
-
     for idx, req in enumerate(requirements):
         if req.startswith("python "):
             requirements[idx] = f"python =={python_version}"

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import sys
+from urllib.request import urlopen
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def get_latest_commit(repository):
+    org, repo = repository.split("/")
+    url = f"https://api.github.com/repos/{org}/{repo}/commits?per_page=1"
+    response = urlopen(url).read()
+    data = json.loads(response.decode())
+    return data[0]["sha"]
 
 
 def main():
@@ -30,8 +40,8 @@ def main():
     if os.environ.get("TEST_UPSTREAM", False):
         dev_req = {
             "pip": [
-                "git+https://github.com/dask/dask",
-                "git+https://github.com/dask/distributed",
+                f"git+https://github.com/dask/dask.git@{get_latest_commit('dask/dask')}",
+                f"git+https://github.com/dask/distributed.git@{get_latest_commit('dask/distributed')}",
             ]
         }
         requirements.append(dev_req)

--- a/ci/create_latest_runtime_meta.py
+++ b/ci/create_latest_runtime_meta.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 
@@ -20,13 +21,20 @@ def main():
     # Ensure Python is pinned to X.Y.Z version currently being used
     python_version = ".".join(map(str, tuple(sys.version_info)[:3]))
     assert sum([req.startswith("python ") for req in requirements]) == 1
+
     for idx, req in enumerate(requirements):
         if req.startswith("python "):
             requirements[idx] = f"python =={python_version}"
 
-    # File compatible with `mamba install --file <...>`
-    with open("latest.txt", "w") as f:
-        f.write("\n".join(requirements))
+    # Optionally install the development version of `dask` and `distributed`
+    if os.environ.get("TEST_UPSTREAM", False):
+        dev_req = {
+            "pip": [
+                "git+https://github.com/dask/dask",
+                "git+https://github.com/dask/distributed",
+            ]
+        }
+        requirements.append(dev_req)
 
     # File compatible with `mamba env create --file <...>`
     env = {"channels": ["coiled", "conda-forge"]}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,6 +7,7 @@ import subprocess
 
 import coiled
 import conda.cli.python_api as Conda
+import dask
 import pytest
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -47,6 +48,10 @@ def get_meta_specifiers() -> dict[str, SpecifierSet]:
 def test_install_dist():
     # Test that versions of packages installed are consistent with those
     # specified in `meta.yaml`
+
+    if Version(dask.__version__).local:
+        pytest.skip("Not valid on upstream build")
+
     meta_specifiers = get_meta_specifiers()
     installed_versions = get_conda_installed_versions()
 


### PR DESCRIPTION
This PR makes it so when a commit message on a PR contains the phrase `test-upstream`, we use the current `main` branch version of `dask` and `distributed` in the `latest` CI build 

Closes https://github.com/coiled/coiled-runtime/issues/89