### PR TITLE
Parquet benchmark

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
 
 # When this workflow is queued, automatically cancel any previous running
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: mamba install boa conda-verify jinja2 packaging pytest
+        run: mamba install boa conda-verify jinja2 packaging pytest fastparquet
 
       - name: Check upstream
         if: github.event_name == 'pull_request' && matrix.runtime-version == 'latest'
@@ -115,9 +115,9 @@ jobs:
         continue-on-error: ${{ matrix.runtime-version == 'latest' }}
         id: tests
         env:
-            DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
+          DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
         run: |
           # Ensure we run additional tests when testing the latest coiled-runtime
           if [[ ${{ matrix.runtime-version }} = 'latest' ]]
@@ -133,7 +133,7 @@ jobs:
       - name: Remove Coiled software environment
         if: ${{ matrix.runtime-version == 'latest' }}
         env:
-            DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
+          DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
         run: |
           # Clean up an Coiled software environments we created just for this CI build
           export COILED_SOFTWARE_NAME=${{ env.COILED_SOFTWARE_NAME }}

--- a/conftest.py
+++ b/conftest.py
@@ -6,9 +6,10 @@ import subprocess
 import sys
 import uuid
 
-import dask
 import pytest
 import s3fs
+
+import dask
 from dask.distributed import Client
 
 try:

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,14 @@ def pytest_addoption(parser):
     parser.addoption(
         "--run-latest", action="store_true", help="Run latest coiled-runtime tests"
     )
+    parser.addoption(
+        "--run-super-slow", action="store_true", help="run super slow tests"
+    )
+
+
+def pytest_runtest_setup(item):
+    if "super_slow" in item.keywords and not item.config.getoption("--run-super-slow"):
+        pytest.skip("need --run-super-slow option to run")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,12 @@ addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config
 markers =
     latest_runtime: marks tests that require the latest coiled-runtime
     stability: marks stability tests
+
+[isort]
+sections = FUTURE,STDLIB,THIRDPARTY,DISTRIBUTED,FIRSTPARTY,LOCALFOLDER
+profile = black
+skip_gitignore = true
+force_to_top = true
+default_section = THIRDPARTY
+known_first_party = dask
+known_distributed = distributed

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,10 +8,9 @@ markers =
     stability: marks stability tests
 
 [isort]
-sections = FUTURE,STDLIB,THIRDPARTY,DISTRIBUTED,FIRSTPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 profile = black
 skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
-known_first_party = dask
-known_distributed = distributed
+known_first_party = dask, coiled, distributed

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config
 markers =
     latest_runtime: marks tests that require the latest coiled-runtime
     stability: marks stability tests
+    super_slow: marks tests that are super slow with the small_cluster fixture
 
 [isort]
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,5 +1,6 @@
-import dask.array as da
 import pytest
+
+import dask.array as da
 
 
 def test_rechunk_in_memory(small_client):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -6,7 +6,6 @@ import shlex
 import subprocess
 
 import coiled
-import conda.cli.python_api as Conda
 import dask
 import pytest
 import yaml
@@ -15,6 +14,8 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
 from packaging.version import Version
 
+Conda = pytest.importorskip("conda.cli.python_api", reason="Conda is not available")
+pytestmark = Conda
 
 def get_conda_installed_versions() -> dict[str, str]:
     """Get conda list packages in a list, and strip headers"""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,8 +5,6 @@ import pathlib
 import shlex
 import subprocess
 
-import coiled
-import dask
 import pytest
 import yaml
 from distributed import Client
@@ -14,8 +12,11 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
 from packaging.version import Version
 
+import coiled
+import dask
+
 Conda = pytest.importorskip("conda.cli.python_api", reason="Conda is not available")
-pytestmark = Conda
+
 
 def get_conda_installed_versions() -> dict[str, str]:
     """Get conda list packages in a list, and strip headers"""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,13 +7,13 @@ import subprocess
 
 import pytest
 import yaml
-from distributed import Client
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
 from packaging.version import Version
 
 import coiled
 import dask
+from distributed import Client
 
 Conda = pytest.importorskip("conda.cli.python_api", reason="Conda is not available")
 

--- a/tests/test_coiled.py
+++ b/tests/test_coiled.py
@@ -1,5 +1,6 @@
-import dask.dataframe as dd
 import pandas as pd
+
+import dask.dataframe as dd
 
 
 def test_quickstart(small_client):

--- a/tests/test_deadlock.py
+++ b/tests/test_deadlock.py
@@ -1,8 +1,9 @@
 import uuid
 
+import pytest
+
 import coiled.v2
 import dask
-import pytest
 from distributed import Client, wait
 
 

--- a/tests/test_h2o_benchmarks.py
+++ b/tests/test_h2o_benchmarks.py
@@ -2,9 +2,10 @@
 h2o-ai benchmark groupby part running on coiled.
 """
 
-import dask.dataframe as dd
 import pandas as pd
 import pytest
+
+import dask.dataframe as dd
 
 
 @pytest.fixture(

--- a/tests/test_parquet_benchmarks.py
+++ b/tests/test_parquet_benchmarks.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import dask.dataframe as dd
+from dask import datasets
+from dask.distributed import wait
+
+if TYPE_CHECKING:
+    from dask.distributed import Client
+
+try:
+    import fastparquet
+except ImportError:
+    fastparquet = False
+
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = False
+
+FASTPARQUET_MARK = pytest.mark.skipif(
+    not fastparquet, reason="fastparquet is not installed"
+)
+PYARROW_MARK = pytest.mark.skipif(not pyarrow, reason="pyarrow is not installed")
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("fastparquet", marks=FASTPARQUET_MARK),
+        pytest.param("pyarrow", marks=PYARROW_MARK),
+    ]
+)
+def engine(request):
+    return request.param
+
+
+def read_write_engines():
+    """Cartesian product of engines returned as a parameterized mark."""
+    return pytest.mark.parametrize(
+        ("read_engine", "write_engine"),
+        [
+            pytest.param(
+                "pyarrow", "fastparquet", marks=(FASTPARQUET_MARK, PYARROW_MARK)
+            ),
+            pytest.param(
+                "fastparquet", "pyarrow", marks=(FASTPARQUET_MARK, PYARROW_MARK)
+            ),
+            pytest.param("pyarrow", "pyarrow", marks=PYARROW_MARK),
+            pytest.param("fastparquet", "fastparquet", marks=FASTPARQUET_MARK),
+        ],
+    )
+
+
+def test_read_parquet_split_row_groups(engine: str, small_client: Client) -> None:
+    """
+    This dataset is ~600 GiB on disk. It has no _metadata. Individual files range from
+    a few hundred MiB to a few GiB on disk, with varying numbers of row groups per file.
+    This means we need to use `split_row_groups=True` to avoid too-large partitions.
+    """
+    df = dd.read_parquet(
+        "s3://daylight-openstreetmap/parquet/osm_elements/release=v1.10/**",
+        engine=engine,
+        require_extension=False,
+        split_row_groups=True,
+    )
+    result = wait(df.persist())
+    assert not result.not_done
+    assert len(result.done) == df.npartitions
+    # Use a loop here to show a useful failure message. all will short-circuit
+    # if there are any False values
+    if not all(r.status == "finished" for r in result.done):
+        for res in result.done:
+            if res.status != "finished":
+                pytest.fail(res.result(), False)
+
+
+def test_read_parquet(engine: str, small_client: Client) -> None:
+    """
+    This dataset is ~5 GiB on disk, although it will grow as Anaconda add more data.
+    Each file is a few hundred MiB to a few GiB on disk with one row group per file.
+    """
+    df = dd.read_parquet(
+        "s3://anaconda-package-data/conda/hourly/",
+        engine=engine,
+    )
+    result = wait(df.persist())
+    assert not result.not_done
+    assert len(result.done) == df.npartitions
+    # Use a loop here to show a useful failure message. all will short-circuit
+    # if there are any False values
+    if not all(r.status == "finished" for r in result.done):
+        for res in result.done:
+            if res.status != "finished":
+                pytest.fail(res.result(), False)
+
+
+@pytest.mark.xfail(
+    reason="gcsfs is not installed in the software environment", strict=True
+)
+def test_read_parquet_google_cloud(engine: str, small_client: Client) -> None:
+    """This dataset lives on Google Cloud."""
+    df = dd.read_parquet(
+        "gcs://catalyst.coop/intake/test/hourly_emissions_epacems.parquet",
+        engine=engine,
+        storage_options={"anon": True},
+    )
+    result = wait(df.persist())
+    assert not result.not_done
+    assert len(result.done) == df.npartitions
+    # Use a loop here to show a useful failure message. all will short-circuit
+    # if there are any False values
+    if not all(r.status == "finished" for r in result.done):
+        for res in result.done:
+            if res.status != "finished":
+                pytest.fail(res.result(), False)
+
+
+@read_write_engines()
+def test_write_parquet(
+    read_engine: str, write_engine: str, small_client: Client, s3_url: str
+) -> None:
+    df = datasets.timeseries()
+    df.to_parquet(s3_url, engine=write_engine, write_metadata_file=False)
+    df2 = dd.read_parquet(s3_url, engine=read_engine)
+
+    result = wait(df2.persist())
+    assert not result.not_done
+    assert len(result.done) == df.npartitions
+    # Use a loop here to show a useful failure message. all will short-circuit
+    # if there are any False values
+    if not all(r.status == "finished" for r in result.done):
+        for res in result.done:
+            if res.status != "finished":
+                pytest.fail(res.result(), False)

--- a/tests/test_parquet_benchmarks.py
+++ b/tests/test_parquet_benchmarks.py
@@ -70,7 +70,7 @@ def test_read_parquet_split_row_groups(engine: str, small_client: Client) -> Non
     assert not result.not_done
     assert len(result.done) == df.npartitions
     # Use a loop here to show a useful failure message. all will short-circuit
-    # if there are any False values
+    # if there are any False values in case there are a lot of tasks.
     if not all(r.status == "finished" for r in result.done):
         for res in result.done:
             if res.status != "finished":
@@ -90,7 +90,7 @@ def test_read_parquet(engine: str, small_client: Client) -> None:
     assert not result.not_done
     assert len(result.done) == df.npartitions
     # Use a loop here to show a useful failure message. all will short-circuit
-    # if there are any False values
+    # if there are any False values in case there are a lot of tasks.
     if not all(r.status == "finished" for r in result.done):
         for res in result.done:
             if res.status != "finished":
@@ -111,7 +111,7 @@ def test_read_parquet_google_cloud(engine: str, small_client: Client) -> None:
     assert not result.not_done
     assert len(result.done) == df.npartitions
     # Use a loop here to show a useful failure message. all will short-circuit
-    # if there are any False values
+    # if there are any False values in case there are a lot of tasks.
     if not all(r.status == "finished" for r in result.done):
         for res in result.done:
             if res.status != "finished":
@@ -130,7 +130,7 @@ def test_write_parquet(
     assert not result.not_done
     assert len(result.done) == df.npartitions
     # Use a loop here to show a useful failure message. all will short-circuit
-    # if there are any False values
+    # if there are any False values in case there are a lot of tasks.
     if not all(r.status == "finished" for r in result.done):
         for res in result.done:
             if res.status != "finished":

--- a/tests/test_parquet_benchmarks.py
+++ b/tests/test_parquet_benchmarks.py
@@ -54,6 +54,7 @@ def read_write_engines():
     )
 
 
+@pytest.mark.super_slow
 def test_read_parquet_split_row_groups(engine: str, small_client: Client) -> None:
     """
     This dataset is ~600 GiB on disk. It has no _metadata. Individual files range from
@@ -97,9 +98,6 @@ def test_read_parquet(engine: str, small_client: Client) -> None:
                 pytest.fail(res.result(), False)
 
 
-@pytest.mark.xfail(
-    reason="gcsfs is not installed in the software environment", strict=True
-)
 def test_read_parquet_google_cloud(engine: str, small_client: Client) -> None:
     """This dataset lives on Google Cloud."""
     df = dd.read_parquet(

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -1,6 +1,7 @@
+import pytest
+
 import dask
 import dask.dataframe as dd
-import pytest
 
 
 @pytest.mark.stability


### PR DESCRIPTION
Adds some (timing?) benchmarks for Parquet I/O on cloud storage.

TODO:

- [x] Add `gcsfs` to the software environment
- [x] Add `fastparquet` to the software environment
- [x] Handle removal of `require_extensions` kwarg

@jrbourbeau @ncclementi Pointers on how to add new packages to the software environment for testing without borking the `coiled-runtime` build are appreciated 😄 