### PR TITLE
Fix commit parsing on non-PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,14 @@ jobs:
 
       - name: Check upstream
         run: |
-          COMMIT="$(git log -n 1 --pretty=format:%s HEAD^2)"
+          if [[ ${{ github.event_name }} == "pull_request" ]]
+          then
+              export REF="HEAD^2"
+          else
+              export REF="HEAD"
+          fi
+
+          COMMIT="$(git log -n 1 --pretty=format:%s $REF)"
           if [[ "$COMMIT" == *"test-upstream"* || ${{ github.event_name }} == "schedule" ]]
           then
             export TEST_UPSTREAM="true"


### PR DESCRIPTION
Should fix 

```
 fatal: ambiguous argument 'HEAD^2': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

that we're seeing in [CI builds on `main`](https://github.com/coiled/coiled-runtime/runs/6276096609?check_suite_focus=true) following https://github.com/coiled/coiled-runtime/pull/91