### PR TITLE
Use consistent hash in cluster names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,12 +64,14 @@ dask.config.set(
     }
 )
 
+ID = uuid.uuid4().hex[:8]
+
 
 @pytest.fixture(scope="module")
 def small_cluster(request):
     module = os.path.basename(request.fspath).split(".")[0]
     with Cluster(
-        name=f"{module}-{uuid.uuid4().hex[:8]}",
+        name=f"{module}-{ID}",
         n_workers=10,
         worker_memory="8 GiB",
         worker_vm_types=["m5.large"],


### PR DESCRIPTION
Today for a single GHA workflow run we use a unique hash for each cluster name (for example):

```
test_shuffle-f769bd1c
test_array-23fb79f4
...
```

This PR makes it so that each cluster name uses the same hash:

```
test_shuffle-f769bd1c
test_array-f769bd1c
...
```

which makes it easier to trace clusters back to a specific GHA workflow run. This type of tracing is nice as, for example, it helps us get a better sense for how much each workflow run costs. 