### PR TITLE
Use spot instances in stability tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config
 markers =
     latest_runtime: marks tests that require the latest coiled-runtime
     stability: marks stability tests
+    backend_options: marks cluster backend options

--- a/tests/stability/conftest.py
+++ b/tests/stability/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    # Ensure stability tests use spot instances by default
+    marker = pytest.mark.backend_options(spot=True)
+    for item in items:
+        # Add a module-level `spot=True` backend option marker if one doesn't already exist
+        module = item.parent
+        if not any(
+            m.kwargs.get("spot", False)
+            for m in module.iter_markers(name="backend_options")
+        ):
+            module.add_marker(marker)

--- a/tests/stability/conftest.py
+++ b/tests/stability/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 def pytest_collection_modifyitems(config, items):
     # Ensure stability tests use spot instances by default
-    marker = pytest.mark.backend_options(spot=True)
+    marker = pytest.mark.backend_options(spot=True, spot_on_demand_fallback=True)
     for item in items:
         # Add a module-level `spot=True` backend option marker if one doesn't already exist
         module = item.parent


### PR DESCRIPTION
This PR updates our stability tests to automatically use spot instances by default. This will make sure we're resilient to workers randomly leaving the cluster. 

Closes https://github.com/coiled/coiled-runtime/issues/122

EDIT: This also has a small cost-savings benefit, but my main motivation for this change is making sure our stability tests are robust when workers go offline 