### PR TITLE
Run upstream build daily instead of weekly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
       - '*'
   pull_request:
   schedule:
-    # Runs "At 00:01 on Sunday" (see https://crontab.guru)
-    - cron: "1 0 * * SUN"
+    # Runs "At 00:01" (see https://crontab.guru)
+    - cron: "1 0 * * *"
 
 concurrency:
   # Include `github.event_name` to avoid pushes to `main` and


### PR DESCRIPTION
Given the relatively low cost estimates from @ntabris over in https://github.com/coiled/coiled-runtime/issues/122#issuecomment-1132024820, I'll propose we run our upstream CI builds once a day instead of once a week

@hayesgb 