### PR TITLE
Parquet tests on AWS open datasets

### DIFF
--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -11,12 +11,14 @@ import pandas
 import pytest
 from coiled.v2 import Cluster
 
+N_WORKERS = 15
+
 
 @pytest.fixture(scope="module")
 def parquet_cluster():
     with Cluster(
         f"parquet-{uuid.uuid4().hex[:8]}",
-        n_workers=15,
+        n_workers=N_WORKERS,
         worker_vm_types=["m5.xlarge"],
         scheduler_vm_types=["m5.xlarge"],
     ) as cluster:
@@ -26,6 +28,8 @@ def parquet_cluster():
 @pytest.fixture(scope="module")
 def parquet_client(parquet_cluster):
     with distributed.Client(parquet_cluster) as client:
+        parquet_cluster.scale(N_WORKERS)
+        parquet_cluster.wait_for_workers(N_WORKERS)
         client.restart()
         yield client
 

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -29,7 +29,7 @@ def parquet_cluster():
 def parquet_client(parquet_cluster):
     with distributed.Client(parquet_cluster) as client:
         parquet_cluster.scale(N_WORKERS)
-        parquet_cluster.wait_for_workers(N_WORKERS)
+        client.wait_for_workers(N_WORKERS)
         client.restart()
         yield client
 

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -43,7 +43,11 @@ def test_read_hive_partitioned_data():
         backend_options={"region": "us-west-2"},
     ) as cluster:
         with distributed.Client(cluster):
-            ddf = dd.read_parquet("s3://ookla-open-data/parquet/**fixed_tiles.parquet")
+            ddf = dd.read_parquet(
+                "s3://ookla-open-data/parquet/**fixed_tiles.parquet",
+                engine="pyarrow",
+                storage_options={"anon": True},
+            )
 
             # The data is already partitioned by year and quarter, but it doesn't
             # fit Dask's partitioning scheme well since we don't support multiindexes.

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -6,60 +6,65 @@ import uuid
 import dask.dataframe as dd
 import distributed
 import pandas
+import pytest
 from coiled.v2 import Cluster
 
 
-def test_read_spark_generated_data():
+@pytest.fixture(scope="module")
+def parquet_cluster():
+    with Cluster(
+        f"parquet-{uuid.uuid4().hex[:8]}",
+        n_workers=15,
+        worker_vm_types=["m5.xlarge"],
+        scheduler_vm_types=["m5.xlarge"],
+    ) as cluster:
+        yield cluster
+
+
+@pytest.fixture(scope="module")
+def parquet_client(parquet_cluster):
+    with distributed.Client(parquet_cluster) as client:
+        client.restart()
+        yield client
+
+
+def test_read_spark_generated_data(parquet_client):
     """
     Read a ~15 GB subset of a ~800 GB spark-generated
     open dataset on AWS.
     """
-    with Cluster(
-        f"genome-{uuid.uuid4().hex[:8]}",
-        n_workers=25,
-        worker_vm_types=["m5.large"],
-        scheduler_vm_types=["m5.large"],
-    ) as cluster:
-        with distributed.Client(cluster):
-            ddf = dd.read_parquet(
-                "s3://coiled-runtime-ci/thousandgenomes_dragen/var_partby_samples/NA21**.parquet",
-                engine="pyarrow",
-                index="sample_id",
-            )
-            ddf.groupby(ddf.index).first().compute()
+    ddf = dd.read_parquet(
+        "s3://coiled-runtime-ci/thousandgenomes_dragen/var_partby_samples/NA21**.parquet",
+        engine="pyarrow",
+        index="sample_id",
+    )
+    ddf.groupby(ddf.index).first().compute()
 
 
-def test_read_hive_partitioned_data():
+def test_read_hive_partitioned_data(parquet_client):
     """
     Read a dataset partitioned by year and quarter.
     """
-    with Cluster(
-        f"ookla-{uuid.uuid4().hex[:8]}",
-        n_workers=25,
-        worker_vm_types=["m5.xlarge"],
-        scheduler_vm_types=["m5.xlarge"],
-    ) as cluster:
-        with distributed.Client(cluster):
-            ddf = dd.read_parquet(
-                "s3://coiled-runtime-ci/ookla-open-data/type=fixed/**.parquet",
-                engine="pyarrow",
+    ddf = dd.read_parquet(
+        "s3://coiled-runtime-ci/ookla-open-data/type=fixed/**.parquet",
+        engine="pyarrow",
+    )
+
+    # The data is already partitioned by year and quarter, but it doesn't
+    # fit Dask's partitioning scheme well since we don't support multiindexes.
+    # This is a lot of work to set the index for something that is already
+    # partitioned! We also go around dask's set_index, which does a huge amount
+    # of extra work, and even takes down instances.
+    def get_period(df):
+        return df.set_index(
+            pandas.PeriodIndex(
+                df.year.astype(str) + "Q" + df.quarter.astype(str),
+                freq="Q",
+                name="period",
             )
+        )
 
-            # The data is already partitioned by year and quarter, but it doesn't
-            # fit Dask's partitioning scheme well since we don't support multiindexes.
-            # This is a lot of work to set the index for something that is already
-            # partitioned! We also go around dask's set_index, which does a huge amount
-            # of extra work, and even takes down instances.
-            def get_period(df):
-                return df.set_index(
-                    pandas.PeriodIndex(
-                        df.year.astype(str) + "Q" + df.quarter.astype(str),
-                        freq="Q",
-                        name="period",
-                    )
-                )
-
-            ddf2 = ddf.map_partitions(get_period, meta=get_period(ddf._meta)).persist()
-            distributed.wait(ddf2)
-            # Enable once we have dask>=2022.3.0
-            # ddf2.divisions = ddf2.compute_current_divisions()
+    ddf2 = ddf.map_partitions(get_period, meta=get_period(ddf._meta)).persist()
+    distributed.wait(ddf2)
+    # Enable once we have dask>=2022.3.0
+    # ddf2.divisions = ddf2.compute_current_divisions()

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -111,8 +111,10 @@ def test_download_throughput(parquet_client, kind):
             with fsspec.open(path) as f:
                 f.read()
 
-        parquet_client.submit(load, path)
+        distributed.wait(parquet_client.submit(load, path))
     elif kind == "pandas":
-        parquet_client.submit(pandas.read_parquet, path, engine="pyarrow")
+        distributed.wait(
+            parquet_client.submit(pandas.read_parquet, path, engine="pyarrow")
+        )
     elif kind == "dask":
         distributed.wait(dd.read_parquet(path, engine="pyarrow").persist())

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -34,6 +34,10 @@ def test_read_spark_generated_data(parquet_client):
     """
     Read a ~15 GB subset of a ~800 GB spark-generated
     open dataset on AWS.
+
+    The dataset was copied from AWS open data on 2022-05-25
+    https://registry.opendata.aws/1000-genomes-data-lakehouse-ready/
+    Citation: https://www.nature.com/articles/s41467-018-08148-z
     """
     ddf = dd.read_parquet(
         "s3://coiled-runtime-ci/thousandgenomes_dragen/var_partby_samples/NA21**.parquet",
@@ -46,6 +50,9 @@ def test_read_spark_generated_data(parquet_client):
 def test_read_hive_partitioned_data(parquet_client):
     """
     Read a dataset partitioned by year and quarter.
+
+    The dataset was copied from AWS open data on 2022-05-25
+    https://registry.opendata.aws/speedtest-global-performance/
     """
     ddf = dd.read_parquet(
         "s3://coiled-runtime-ci/ookla-open-data/type=fixed/**.parquet",
@@ -68,8 +75,6 @@ def test_read_hive_partitioned_data(parquet_client):
 
     ddf2 = ddf.map_partitions(get_period, meta=get_period(ddf._meta)).persist()
     distributed.wait(ddf2)
-    # Enable once we have dask>=2022.3.0
-    # ddf2.divisions = ddf2.compute_current_divisions()
 
 
 def test_write_wide_data(parquet_client, s3_url):

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -1,0 +1,64 @@
+"""
+Parquet-related benchmarks.
+"""
+import uuid
+
+import dask.dataframe as dd
+import distributed
+import pandas
+from coiled.v2 import Cluster
+
+
+def test_read_spark_generated_data():
+    """
+    Read a ~15 GB subset of a ~800 GB spark-generated
+    open dataset on AWS.
+    """
+    with Cluster(
+        f"genome-{uuid.uuid4().hex[:8]}",
+        n_workers=25,
+        worker_vm_types=["m5.large"],
+        scheduler_vm_types=["m5.large"],
+        backend_options={"region": "us-east-1"},
+    ) as cluster:
+        with distributed.Client(cluster):
+            ddf = dd.read_parquet(
+                "s3://aws-roda-hcls-datalake/thousandgenomes_dragen/var_partby_samples/NA21**.parquet",
+                engine="pyarrow",
+                storage_options={"anon": True},
+                index="sample_id",
+            )
+            ddf.groupby(ddf.index).first().compute()
+
+
+def test_read_hive_partitioned_data():
+    """
+    Read a dataset partitioned by year and quarter.
+    """
+    with Cluster(
+        f"ookla-{uuid.uuid4().hex[:8]}",
+        n_workers=15,
+        worker_vm_types=["m5.xlarge"],
+        scheduler_vm_types=["m5.xlarge"],
+        backend_options={"region": "us-west-2"},
+    ) as cluster:
+        with distributed.Client(cluster):
+            ddf = dd.read_parquet("s3://ookla-open-data/parquet/**fixed_tiles.parquet")
+
+            # The data is already partitioned by year and quarter, but it doesn't
+            # fit Dask's partitioning scheme well since we don't support multiindexes.
+            # This is a lot of work to set the index for something that is already
+            # partitioned! We also go around dask's set_index, which does a huge amount
+            # of extra work, and even takes down instances.
+            def get_period(df):
+                return df.set_index(
+                    pandas.PeriodIndex(
+                        df.year.astype(str) + "Q" + df.quarter.astype(str),
+                        freq="Q",
+                        name="period",
+                    )
+                )
+
+            ddf2 = ddf.map_partitions(get_period, meta=get_period(ddf._meta)).persist()
+            distributed.wait(ddf2)
+            ddf2.divisions = ddf2.compute_current_divisions()

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -95,7 +95,7 @@ def test_write_wide_data(parquet_client, s3_url):
 
 
 @pytest.mark.parametrize("kind", ("s3fs", "pandas", "dask"))
-def test_s3_ec2_throughput(parquet_client, kind):
+def test_download_throughput(parquet_client, kind):
     # Test throughput for downloading and parsing a ~500 MB file
     path = (
         "s3://coiled-runtime-ci/ookla-open-data/"


### PR DESCRIPTION
This is the start of some parquet-related integration tests running against open data on AWS. They constitute a "large data" (10s of GiB) test against two different partitioning schemes.

TODO:

- [x] Write "large data" tests.
- [ ] ~~Round-trip data with spark~~
- [x] Write a performance regression test against EC2 <-> S3 bandwidth
