### PR TITLE
Update GHA job concurrency

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,7 +8,7 @@ on:
 concurrency:
   # Include `github.event_name` to avoid pushes to `main` and
   # scheduled jobs canceling one another
-  group: ${{ github.event_name }}-${{ github.ref }}
+  group: nightly-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 concurrency:
   # Include `github.event_name` to avoid pushes to `main` and
   # scheduled jobs canceling one another
-  group: ${{ github.event_name }}-${{ github.ref }}
+  group: tests-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
I noticed our cron job for publishing a nightly version of `coiled-runtime` is currently cancelling the cron job for running nightly tests. This PR fixes that 

cc @ncclementi 