### PR TITLE
Re-enable test_deadlock.py::test_repeated_merge_spill

### DIFF
--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -5,6 +5,7 @@ import dask
 from distributed import Client, wait
 
 
+@pytest.mark.latest_runtime
 def test_repeated_merge_spill():
     with coiled.v2.Cluster(
         name=f"test_deadlock-{uuid.uuid4().hex}",


### PR DESCRIPTION
Should be fixed by now and if not I really would like to know