### PR TITLE
Add cluster spinup benchmark

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -126,8 +126,13 @@ def s3_scratch(s3):
 
 
 @pytest.fixture(scope="function")
-def s3_url(s3, s3_scratch, request):
-    url = f"{s3_scratch}/{request.node.originalname}-{uuid.uuid4().hex}"
+def s3_url(s3, s3_scratch, test_name):
+    url = f"{s3_scratch}/{test_name}-{uuid.uuid4().hex}"
     s3.mkdirs(url, exist_ok=False)
     yield url
     s3.rm(url, recursive=True)
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.originalname

--- a/tests/benchmarks/test_coiled.py
+++ b/tests/benchmarks/test_coiled.py
@@ -1,0 +1,9 @@
+import uuid
+
+from coiled import Cluster
+
+
+def test_default_cluster_spinup_time(test_name):
+
+    with Cluster(name=f"{test_name}-{uuid.uuid4().hex[:8]}"):
+        pass


### PR DESCRIPTION
Let's monitor how long it takes to spin up a Coiled cluster with default parameters. This will let us, among other things, see what impact adding new packages to the runtime has on cluster spin up time 

Closes https://github.com/coiled/coiled-runtime/issues/111