### PR TITLE
Handle Python version combinations when creating Coiled software environments 

### DIFF
--- a/.github/workflows/software-environments-stable.yml
+++ b/.github/workflows/software-environments-stable.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         runtime-version: ["0.0.3", "0.0.4"]
         server: ["https://cloud.coiled.io", "https://staging.coiledhq.com"]
         include:
@@ -22,6 +22,13 @@ jobs:
             token-name: COILED_BENCHMARK_BOT_TOKEN
           - server: "https://staging.coiledhq.com"
             token-name: COILED_STAGING_BENCHMARK_BOT_TOKEN
+          - python-version: "3.7"
+            runtime-version: "0.0.3"
+        exclude:
+          # `coiled-runtime=0.0.3` pins to a version of Dask
+          # that doesn't support Python 3.10
+          - python-version: "3.10"
+            runtime-version: "0.0.3"
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
In https://github.com/coiled/coiled-runtime/pull/180, I didn't account for `coiled-runtime=0.0.4` supporting Python 3.8 - 3.10, while `coiled-runtime=0.0.3` supports Python 3.7 - 3.9. This PR makes sure we have the correct runtime / Python version combinations 