### PR TITLE
Fix cluster dump loggic when raise occurs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -184,11 +184,11 @@ def upload_cluster_dump(request, s3_cluster_dump_url, s3_storage_options):
                 failed = request.node.rep_call.failed
             except AttributeError:
                 failed = False
-
-        cluster_dump = strtobool(os.environ.get("CLUSTER_DUMP", "false"))
-        if cluster_dump and failed:
-            dump_path = f"{s3_cluster_dump_url}/{cluster.name}/{request.node.name}"
-            logger.error(f"Cluster state dump can be found at: {dump_path}")
-            client.dump_cluster_state(dump_path, **s3_storage_options)
+        finally:
+            cluster_dump = strtobool(os.environ.get("CLUSTER_DUMP", "false"))
+            if cluster_dump and failed:
+                dump_path = f"{s3_cluster_dump_url}/{cluster.name}/{request.node.name}"
+                logger.error(f"Cluster state dump can be found at: {dump_path}")
+                client.dump_cluster_state(dump_path, **s3_storage_options)
 
     yield _upload_cluster_dump


### PR DESCRIPTION
Currently, when we go through the path in line 177 we raise, causing the last piece of code not to run. This PR fixes the problem

https://github.com/coiled/coiled-runtime/blob/45bc8e9efa852fcf84c5a78289691157f48fc15e/conftest.py#L168-L194