### PR TITLE
Add runn tests for 0.0.4 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest", "0.0.3"]
+        runtime-version: ["latest", "0.0.3", "0.0.4"]
 
     steps:
       - uses: actions/checkout@v2
@@ -159,7 +159,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest", "0.0.3"]
+        runtime-version: ["latest", "0.0.3", , "0.0.4"]
 
     steps:
       - uses: actions/checkout@v2
@@ -204,7 +204,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]
-        runtime-version: ["latest", "0.0.3"]
+        runtime-version: ["latest", "0.0.3", "0.0.4"]
         include:
           - python-version: "3.9"
             runtime-version: "latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,7 +159,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest", "0.0.3", , "0.0.4"]
+        runtime-version: ["latest", "0.0.3", "0.0.4"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently, we are not the tests for 0.0.4, this PR includes these cases. This will make CI much longer, I wonder to what extent we need to keep running the tests in 0.0.3. 

Opinions? 

cc: @hayesgb and @ian-r-rose 