### PR TITLE
Start using semantic versioning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "coiled-runtime" %}
-{% set version = "0.0.5" + environ.get("VERSION_SUFFIX", '') %}
+{% set version = "0.1.0" + environ.get("VERSION_SUFFIX", '') %}
 {% set dask_version = environ.get("DASK_VERSION", "2022.6.0") %}
 {% set distributed_version = environ.get("DISTRIBUTED_VERSION", "2022.6.0") %}
 


### PR DESCRIPTION
From now on we will use semantic versioning.  For the next release we will use 0.1.0
This targets  #194 and #133 

I don't want to automatically close the issues until we see this in action (next release) but want to make it visible.
cc: @ian-r-rose for visibility