### PR TITLE
Integration tests for adaptive scaling

### DIFF
--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -1,0 +1,41 @@
+import uuid
+import pytest
+from coiled.v2 import Cluster
+from dask.distributed import Client
+from distributed import Event
+import time
+
+
+@pytest.mark.stability
+@pytest.mark.parametrize("minimum", (0, 1))
+@pytest.mark.parametrize("scatter", (False, pytest.param(True, marks=[pytest.mark.xfail("dask/distributed#6686")])))
+def test_scale_up_on_task_load(minimum, scatter):
+     with Cluster(
+        name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
+        n_workers=minimum,
+        worker_vm_types=["t3.medium"],
+    ) as cluster:
+        with Client(cluster) as client:
+            assert len(cluster.observed) == minimum
+            adapt = cluster.adapt(minimum=minimum, maximum=10, interval="5s", wait_count=3)
+            time.sleep(10)
+            assert len(adapt.log) == 0
+            ev_fan_out = Event(name="fan-out", client=client)
+
+            def clog(x: int, ev: Event) -> int:
+                ev.wait()
+                return x
+
+            numbers = range(100)
+            if scatter is True:
+                numbers = client.scatter(list(numbers))
+
+            futures = client.map(clog, numbers, ev=ev_fan_out)
+
+            # Scale up within 5 minutes
+            client.wait_for_workers(n_workers=10, timeout=300)
+            assert len(adapt.log) <= 2
+            assert adapt.log[-1][1] == {"status": "up", "n": 10}
+            ev_fan_out.set()
+            client.gather(futures)
+

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -7,7 +7,8 @@ from coiled.v2 import Cluster
 from dask import delayed
 from dask.distributed import Client, Event, Semaphore, wait
 
-TIMEOUT_THRESHOLD = 600 # 10 minutes
+TIMEOUT_THRESHOLD = 600  # 10 minutes
+
 
 @pytest.mark.stability
 @pytest.mark.parametrize("minimum", (0, 1))
@@ -153,6 +154,9 @@ def test_adapt_to_changing_workload(minimum: int):
             )
 
 
+@pytest.mark.skip(
+    reason="The test behavior is unreliable and may lead to very long runtime (see: coiled-runtime#211)"
+)
 @pytest.mark.stability
 @pytest.mark.parametrize("minimum", (0, 1))
 def test_adapt_to_memory_intensive_workload(minimum):
@@ -219,7 +223,7 @@ def test_adapt_to_memory_intensive_workload(minimum):
 
             ev_barrier.set()
             wait(fut)
-            fut = memory_intensive_processing()
+            fut = client.compute(memory_intensive_processing())
 
             # Scale up to maximum on postprocessing
             start = time.monotonic()

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -6,7 +6,7 @@ import dask.array as da
 import pytest
 from coiled.v2 import Cluster
 from dask import delayed
-from dask.distributed import Client, Event, Semaphore, wait
+from dask.distributed import Client, Event, wait
 
 TIMEOUT_THRESHOLD = 1800  # 10 minutes
 

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -169,8 +169,8 @@ def test_adapt_to_memory_intensive_workload(minimum):
             assert len(adapt.log) == 0
 
             def memory_intensive_preprocessing():
-                matrix = da.random.random((50000, 50000), chunks=(50000, 100))
-                rechunked = matrix.rechunk((100, 50000))
+                matrix = da.random.random((40000, 40000), chunks=(40000, 500))
+                rechunked = matrix.rechunk((500, 40000))
                 reduction = rechunked.sum()
                 return reduction
 
@@ -187,9 +187,9 @@ def test_adapt_to_memory_intensive_workload(minimum):
                 return barrier
 
             def memory_intensive_postprocessing(data):
-                matrix = da.random.random((50000, 50000), chunks=(50000, 100))
+                matrix = da.random.random((40000, 40000), chunks=(40000, 500))
                 matrix = matrix + da.from_delayed(data, shape=(1,), dtype="float")
-                rechunked = matrix.rechunk((100, 50000))
+                rechunked = matrix.rechunk((500, 40000))
                 reduction = rechunked.sum()
                 return reduction
 

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -28,7 +28,6 @@ def test_scale_up_on_task_load(minimum, scatter):
         wait_for_workers=True,
     ) as cluster:
         with Client(cluster) as client:
-            assert len(cluster.observed) == minimum
             adapt = cluster.adapt(minimum=minimum, maximum=maximum)
             time.sleep(adapt.interval * 2.1)  # Ensure enough time for system to adapt
             assert len(adapt.log) == 0

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -12,7 +12,7 @@ TIMEOUT_THRESHOLD = 1800  # 10 minutes
 
 
 @pytest.mark.stability
-@pytest.mark.parametrize("minimum,threshold", [(0, 240), (1, 120)])
+@pytest.mark.parametrize("minimum,threshold", [(0, 300), (1, 150)])
 @pytest.mark.parametrize(
     "scatter",
     (
@@ -118,7 +118,7 @@ def test_adapt_to_changing_workload(minimum: int):
                 client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
                 end = time.monotonic()
                 duration_first_scale_up = end - start
-                assert duration_first_scale_up < 120
+                assert duration_first_scale_up < 150
                 assert len(cluster.observed) == maximum
                 assert adapt.log[-1][1]["status"] == "up"
 
@@ -141,7 +141,7 @@ def test_adapt_to_changing_workload(minimum: int):
                 client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
                 end = time.monotonic()
                 duration_second_scale_up = end - start
-                assert duration_second_scale_up < 120
+                assert duration_second_scale_up < 150
                 assert len(cluster.observed) == maximum
                 assert adapt.log[-1][1]["status"] == "up"
 

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -68,8 +68,8 @@ def test_adapt_to_changing_workload():
     a varying task load and scales up or down. This also asserts that no recomputation
     is caused by the scaling.
     """
-    minimum=0
-    maximum=10
+    minimum = 0
+    maximum = 10
     fan_out_size = 100
     with Cluster(
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -32,7 +32,7 @@ def test_scale_up_on_task_load(minimum, threshold, scatter):
         wait_for_workers=True,
         # Note: We set allowed-failures to ensure that no tasks are not retried upon ungraceful shutdown behavior
         # during adaptive scaling but we receive a KilledWorker() instead.
-        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": 0},
+        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0"},
     ) as cluster:
         with Client(cluster) as client:
             adapt = cluster.adapt(minimum=minimum, maximum=maximum)
@@ -78,7 +78,7 @@ def test_adapt_to_changing_workload(minimum: int):
         wait_for_workers=True,
         # Note: We set allowed-failures to ensure that no tasks are not retried upon ungraceful shutdown behavior
         # during adaptive scaling but we receive a KilledWorker() instead.
-        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": 0},
+        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0"},
     ) as cluster:
         with Client(cluster) as client:
             adapt = cluster.adapt(minimum=minimum, maximum=maximum)
@@ -189,7 +189,7 @@ def test_adapt_to_memory_intensive_workload(minimum):
         wait_for_workers=True,
         # Note: We set allowed-failures to ensure that no tasks are not retried upon ungraceful shutdown behavior
         # during adaptive scaling but we receive a KilledWorker() instead.
-        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": 0},
+        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0"},
     ) as cluster:
         with Client(cluster) as client:
             adapt = cluster.adapt(minimum=minimum, maximum=maximum)

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -20,7 +20,7 @@ TIMEOUT_THRESHOLD = 1800  # 10 minutes
     ),
 )
 def test_scale_up_on_task_load(minimum, threshold, scatter):
-    """Tests that adaptive scaling reacts in a reasonable amount of time to 
+    """Tests that adaptive scaling reacts in a reasonable amount of time to
     an increased task load and scales up.
     """
     maximum = 10
@@ -61,8 +61,8 @@ def test_scale_up_on_task_load(minimum, threshold, scatter):
 @pytest.mark.stability
 @pytest.mark.parametrize("minimum", (0, 1))
 def test_adapt_to_changing_workload(minimum: int):
-    """Tests that adaptive scaling reacts within a reasonable amount of time to 
-    a varying task load and scales up or down. This also asserts that no recomputation 
+    """Tests that adaptive scaling reacts within a reasonable amount of time to
+    a varying task load and scales up or down. This also asserts that no recomputation
     is caused by the scaling.
     """
     maximum = 10
@@ -81,7 +81,9 @@ def test_adapt_to_changing_workload(minimum: int):
             def clog(x: int, ev: Event, sem: Semaphore, **kwargs) -> int:
                 # Ensure that no recomputation happens by decrementing a countdown on a semaphore
                 acquired = sem.acquire(timeout=1)
-                assert acquired is True, "Could not acquire semaphore, likely recomputation happened."
+                assert (
+                    acquired is True
+                ), "Could not acquire semaphore, likely recomputation happened."
                 ev.wait()
                 return x
 
@@ -185,7 +187,7 @@ def test_adapt_to_changing_workload(minimum: int):
 @pytest.mark.parametrize("minimum", (0, 1))
 def test_adapt_to_memory_intensive_workload(minimum):
     """Tests that adaptive scaling reacts within a reasonable amount of time to a varying task and memory load.
-    
+
     Note: This tests currently results in spilling and very long runtimes.
     """
     maximum = 10

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -7,7 +7,7 @@ from coiled.v2 import Cluster
 from dask import delayed
 from dask.distributed import Client, Event, wait
 
-TIMEOUT_THRESHOLD = 1800  # 10 minutes
+TIMEOUT_THRESHOLD = 900  # 15 minutes
 
 
 @pytest.mark.stability
@@ -49,9 +49,9 @@ def test_scale_up_on_task_load(minimum, threshold, scatter):
 
             futures = client.map(clog, numbers, ev=ev_fan_out)
 
-            end = time.monotonic()
-            client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
             start = time.monotonic()
+            client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
+            end = time.monotonic()
             duration = end - start
             assert duration < threshold, duration
             assert len(adapt.log) <= 2

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -156,7 +156,6 @@ def test_adapt_to_changing_workload():
             assert len(cluster.observed) == minimum
             assert adapt.log[-1][1]["status"] == "down"
             return (
-                duration_first_scale_up,
                 duration_first_scale_down,
                 duration_second_scale_up,
                 duration_second_scale_down,
@@ -166,7 +165,7 @@ def test_adapt_to_changing_workload():
 @pytest.mark.stability
 def test_adaptive_rechunk_stress():
     """Tests adaptive scaling in a transfer-heavy workload that reduces its memory load
-     in a series of rechunking and dimensional reduction steps.
+    in a series of rechunking and dimensional reduction steps.
     """
     with Cluster(
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
@@ -178,6 +177,7 @@ def test_adaptive_rechunk_stress():
         environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0"},
     ) as cluster:
         with Client(cluster) as client:
+
             def workload(arr):
                 arr = arr.sum(axis=[3])
                 arr = (
@@ -201,7 +201,7 @@ def test_adaptive_rechunk_stress():
                 )
             )
             wait(arr)
-            
+
             cluster.adapt(
                 minimum=1,
                 maximum=32,
@@ -236,6 +236,7 @@ def test_adapt_to_memory_intensive_workload(minimum):
         environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0"},
     ) as cluster:
         with Client(cluster) as client:
+
             def memory_intensive_processing():
                 matrix = da.random.random((40000, 40000), chunks=(40000, 500))
                 rechunked = matrix.rechunk((500, 40000))
@@ -306,7 +307,6 @@ def test_adapt_to_memory_intensive_workload(minimum):
             assert len(cluster.observed) == minimum
             assert adapt.log[-1][1]["status"] == "down"
             return (
-                duration_first_scale_up,
                 duration_first_scale_down,
                 duration_second_scale_up,
                 duration_second_scale_down,

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 
+import dask
 import dask.array as da
 import pytest
 from coiled.v2 import Cluster
@@ -67,117 +68,106 @@ def test_adapt_to_changing_workload(minimum: int):
     """
     maximum = 10
     fan_out_size = 100
-    with Cluster(
-        name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
-        n_workers=5,
-        worker_vm_types=["t3.medium"],
-        wait_for_workers=True,
-    ) as cluster:
-        with Client(cluster) as client:
-            adapt = cluster.adapt(minimum=minimum, maximum=maximum)
-            assert len(adapt.log) == 0
+    # Note: We set allowed-failures to ensure that no tasks are not retried upon ungraceful shutdown behavior
+    # during adative scaling but we receive a KilledWorker() instead.
+    with dask.config.set({"distributed.scheduler.allowed-failures": 0}):
+        with Cluster(
+            name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
+            n_workers=5,
+            worker_vm_types=["t3.medium"],
+            wait_for_workers=True,
+        ) as cluster:
+            with Client(cluster) as client:
+                adapt = cluster.adapt(minimum=minimum, maximum=maximum)
+                assert len(adapt.log) == 0
 
-            @delayed
-            def clog(x: int, ev: Event, sem: Semaphore, **kwargs) -> int:
-                # Ensure that no recomputation happens by decrementing a countdown on a semaphore
-                acquired = sem.acquire(timeout=1)
-                assert (
-                    acquired is True
-                ), "Could not acquire semaphore, likely recomputation happened."
-                ev.wait()
-                return x
+                @delayed
+                def clog(x: int, ev: Event, **kwargs) -> int:
+                    ev.wait()
+                    return x
 
-            def workload(
-                fan_out_size,
-                ev_fan_out,
-                sem_fan_out,
-                ev_barrier,
-                sem_barrier,
-                ev_final_fan_out,
-                sem_final_fan_out,
-            ):
-                fan_out = [
-                    clog(i, ev=ev_fan_out, sem=sem_fan_out) for i in range(fan_out_size)
-                ]
-                barrier = clog(delayed(sum)(fan_out), ev=ev_barrier, sem=sem_barrier)
-                final_fan_out = [
-                    clog(i, ev=ev_final_fan_out, sem=sem_final_fan_out, barrier=barrier)
-                    for i in range(fan_out_size)
-                ]
-                return final_fan_out
+                def workload(
+                    fan_out_size,
+                    ev_fan_out,
+                    ev_barrier,
+                    ev_final_fan_out,
+                ):
+                    fan_out = [
+                        clog(i, ev=ev_fan_out) for i in range(fan_out_size)
+                    ]
+                    barrier = clog(delayed(sum)(fan_out), ev=ev_barrier)
+                    final_fan_out = [
+                        clog(i, ev=ev_final_fan_out, barrier=barrier)
+                        for i in range(fan_out_size)
+                    ]
+                    return final_fan_out
 
-            sem_fan_out = Semaphore(name="fan-out", max_leases=fan_out_size)
-            ev_fan_out = Event(name="fan-out", client=client)
-            sem_barrier = Semaphore(name="barrier", max_leases=1)
-            ev_barrier = Event(name="barrier", client=client)
-            sem_final_fan_out = Semaphore(name="final-fan-out", max_leases=fan_out_size)
-            ev_final_fan_out = Event(name="final-fan-out", client=client)
+                ev_fan_out = Event(name="fan-out", client=client)
+                ev_barrier = Event(name="barrier", client=client)
+                ev_final_fan_out = Event(name="final-fan-out", client=client)
 
-            fut = client.compute(
-                workload(
-                    fan_out_size=fan_out_size,
-                    ev_fan_out=ev_fan_out,
-                    sem_fan_out=sem_fan_out,
-                    ev_barrier=ev_barrier,
-                    sem_barrier=sem_barrier,
-                    ev_final_fan_out=ev_final_fan_out,
-                    sem_final_fan_out=sem_final_fan_out,
+                fut = client.compute(
+                    workload(
+                        fan_out_size=fan_out_size,
+                        ev_fan_out=ev_fan_out,
+                        ev_barrier=ev_barrier,
+                        ev_final_fan_out=ev_final_fan_out,
+                    )
                 )
-            )
 
-            # Scale up to maximum
-            start = time.monotonic()
-            client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
-            end = time.monotonic()
-            duration_first_scale_up = end - start
-            assert duration_first_scale_up < 120
-            assert len(cluster.observed) == maximum
-            assert adapt.log[-1][1]["status"] == "up"
+                # Scale up to maximum
+                start = time.monotonic()
+                client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
+                end = time.monotonic()
+                duration_first_scale_up = end - start
+                assert duration_first_scale_up < 120
+                assert len(cluster.observed) == maximum
+                assert adapt.log[-1][1]["status"] == "up"
 
-            ev_fan_out.set()
-            # Scale down to a single worker
-            start = time.monotonic()
-            while len(cluster.observed) > 1:
-                if time.monotonic() - start >= TIMEOUT_THRESHOLD:
-                    raise TimeoutError()
-                time.sleep(0.1)
-            end = time.monotonic()
-            duration_first_scale_down = end - start
-            assert duration_first_scale_down < 330
-            assert len(cluster.observed) == 1
-            assert adapt.log[-1][1]["status"] == "down"
+                ev_fan_out.set()
+                # Scale down to a single worker
+                start = time.monotonic()
+                while len(cluster.observed) > 1:
+                    if time.monotonic() - start >= TIMEOUT_THRESHOLD:
+                        raise TimeoutError()
+                    time.sleep(0.1)
+                end = time.monotonic()
+                duration_first_scale_down = end - start
+                assert duration_first_scale_down < 330
+                assert len(cluster.observed) == 1
+                assert adapt.log[-1][1]["status"] == "down"
 
-            ev_barrier.set()
-            # Scale up to maximum again
-            start = time.monotonic()
-            client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
-            end = time.monotonic()
-            duration_second_scale_up = end - start
-            assert duration_second_scale_up < 120
-            assert len(cluster.observed) == maximum
-            assert adapt.log[-1][1]["status"] == "up"
+                ev_barrier.set()
+                # Scale up to maximum again
+                start = time.monotonic()
+                client.wait_for_workers(n_workers=maximum, timeout=TIMEOUT_THRESHOLD)
+                end = time.monotonic()
+                duration_second_scale_up = end - start
+                assert duration_second_scale_up < 120
+                assert len(cluster.observed) == maximum
+                assert adapt.log[-1][1]["status"] == "up"
 
-            ev_final_fan_out.set()
-            client.gather(fut)
-            del fut
+                ev_final_fan_out.set()
+                client.gather(fut)
+                del fut
 
-            # Scale down to minimum
-            start = time.monotonic()
-            while len(cluster.observed) > minimum:
-                if time.monotonic() - start >= TIMEOUT_THRESHOLD:
-                    raise TimeoutError()
-                time.sleep(0.1)
-            end = time.monotonic()
-            duration_second_scale_down = end - start
-            assert duration_second_scale_down < 330
-            assert len(cluster.observed) == minimum
-            assert adapt.log[-1][1]["status"] == "down"
-            return (
-                duration_first_scale_up,
-                duration_first_scale_down,
-                duration_second_scale_up,
-                duration_second_scale_down,
-            )
+                # Scale down to minimum
+                start = time.monotonic()
+                while len(cluster.observed) > minimum:
+                    if time.monotonic() - start >= TIMEOUT_THRESHOLD:
+                        raise TimeoutError()
+                    time.sleep(0.1)
+                end = time.monotonic()
+                duration_second_scale_down = end - start
+                assert duration_second_scale_down < 330
+                assert len(cluster.observed) == minimum
+                assert adapt.log[-1][1]["status"] == "down"
+                return (
+                    duration_first_scale_up,
+                    duration_first_scale_down,
+                    duration_second_scale_up,
+                    duration_second_scale_down,
+                )
 
 
 @pytest.mark.skip(

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -1,7 +1,6 @@
 import time
 import uuid
 
-import dask
 import dask.array as da
 import pytest
 from coiled.v2 import Cluster

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -42,7 +42,7 @@ def test_scale_up_on_task_load(minimum, scatter):
             futures = client.map(clog, numbers, ev=ev_fan_out)
 
             # Scale up within 5 minutes
-            client.wait_for_workers(n_workers=maximum, timeout=300)
+            client.wait_for_workers(n_workers=maximum, timeout=360)
             assert len(adapt.log) <= 2
             assert adapt.log[-1][1] == {"status": "up", "n": maximum}
             ev_fan_out.set()
@@ -93,7 +93,7 @@ def test_adapt_to_changing_workload(minimum: int):
             )
 
             # Scale up to maximum
-            client.wait_for_workers(n_workers=maximum, timeout=300)
+            client.wait_for_workers(n_workers=maximum, timeout=420)
             assert len(cluster.observed) == maximum
             assert adapt.log[-1][1]["status"] == "up"
 
@@ -105,12 +105,11 @@ def test_adapt_to_changing_workload(minimum: int):
             end = time.monotonic()
             assert len(cluster.observed) == 1
             assert adapt.log[-1][1]["status"] == "down"
-            # Do not take longer than 5 minutes to scale down
-            assert end - start < 300
+            assert end - start < 420
 
             ev_barrier.set()
             # Scale up to maximum again
-            client.wait_for_workers(n_workers=maximum, timeout=300)
+            client.wait_for_workers(n_workers=maximum, timeout=420)
             while len(cluster.observed) < maximum:
                 time.sleep(0.1)
             assert len(cluster.observed) == maximum
@@ -126,8 +125,7 @@ def test_adapt_to_changing_workload(minimum: int):
             end = time.monotonic()
             assert len(cluster.observed) == minimum
             assert adapt.log[-1][1]["status"] == "down"
-            # Do not take longer than 5 minutes to scale down
-            assert end - start < 300
+            assert end - start < 420
 
 
 @pytest.mark.stability

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -1,18 +1,24 @@
-import pytest
 import time
 import uuid
 
+import dask.array as da
+import pytest
 from coiled.v2 import Cluster
-from dask.distributed import Client, Event, Semaphore
+from dask import delayed
+from dask.distributed import Client, Event, Semaphore, wait
 
 
 @pytest.mark.stability
 @pytest.mark.parametrize("minimum", (0, 1))
 @pytest.mark.parametrize(
     "scatter",
-    (False, pytest.param(True, marks=[pytest.mark.xfail("dask/distributed#6686")])),
+    (
+        False,
+        pytest.param(True, marks=[pytest.mark.xfail(reason="dask/distributed#6686")]),
+    ),
 )
 def test_scale_up_on_task_load(minimum, scatter):
+    maximum = 10
     with Cluster(
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
         n_workers=minimum,
@@ -20,7 +26,7 @@ def test_scale_up_on_task_load(minimum, scatter):
     ) as cluster:
         with Client(cluster) as client:
             assert len(cluster.observed) == minimum
-            adapt = cluster.adapt(minimum=minimum, maximum=10)
+            adapt = cluster.adapt(minimum=minimum, maximum=maximum)
             time.sleep(adapt.interval * 2.1)  # Ensure enough time for system to adapt
             assert len(adapt.log) == 0
             ev_fan_out = Event(name="fan-out", client=client)
@@ -36,9 +42,9 @@ def test_scale_up_on_task_load(minimum, scatter):
             futures = client.map(clog, numbers, ev=ev_fan_out)
 
             # Scale up within 5 minutes
-            client.wait_for_workers(n_workers=10, timeout=300)
+            client.wait_for_workers(n_workers=maximum, timeout=300)
             assert len(adapt.log) <= 2
-            assert adapt.log[-1][1] == {"status": "up", "n": 10}
+            assert adapt.log[-1][1] == {"status": "up", "n": maximum}
             ev_fan_out.set()
             client.gather(futures)
 
@@ -46,11 +52,11 @@ def test_scale_up_on_task_load(minimum, scatter):
 @pytest.mark.stability
 @pytest.mark.parametrize("minimum", (0, 1))
 def test_adapt_to_changing_workload(minimum: int):
-    maximum = 20
+    maximum = 10
     fan_out_size = 100
     with Cluster(
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
-        n_workers=10,
+        n_workers=5,
         worker_vm_types=["t3.medium"],
     ) as cluster:
         with Client(cluster) as client:
@@ -107,7 +113,7 @@ def test_adapt_to_changing_workload(minimum: int):
             client.wait_for_workers(n_workers=maximum, timeout=300)
             while len(cluster.observed) < maximum:
                 time.sleep(0.1)
-            assert len(cluster.observed) == 20
+            assert len(cluster.observed) == maximum
             assert adapt.log[-1][1]["status"] == "up"
 
             ev_final_fan_out.set()
@@ -122,3 +128,87 @@ def test_adapt_to_changing_workload(minimum: int):
             assert adapt.log[-1][1]["status"] == "down"
             # Do not take longer than 5 minutes to scale down
             assert end - start < 300
+
+
+@pytest.mark.stability
+@pytest.mark.parametrize("minimum", (0, 1))
+def test_adapt_to_memory_intensive_workload(minimum):
+    maximum = 10
+    with Cluster(
+        name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
+        n_workers=minimum,
+        worker_vm_types=["t3.medium"],
+    ) as cluster:
+        with Client(cluster) as client:
+            assert len(cluster.observed) == minimum
+            adapt = cluster.adapt(minimum=minimum, maximum=maximum)
+            assert len(adapt.log) == 0
+
+            def memory_intensive_preprocessing():
+                matrix = da.random.random((48000, 48000))
+                rechunked = matrix.rechunk((matrix.shape[0], 200)).rechunk(
+                    (200, matrix.shape[1])
+                )
+                reduction = rechunked.sum()
+                return reduction
+
+            @delayed
+            def clog(x, ev: Event):
+                ev.wait()
+                return x
+
+            def compute_intensive_barrier_task(data, ev: Event):
+                barrier = clog(data, ev)
+                return barrier
+
+            def memory_intensive_postprocessing(data):
+                matrix = da.random.random((48000, 48000))
+                matrix = matrix + da.from_delayed(data, shape=(1,), dtype="float")
+                rechunked = matrix.rechunk((matrix.shape[0], 200)).rechunk(
+                    (200, matrix.shape[1])
+                )
+                reduction = rechunked.sum()
+                return reduction
+
+            ev_barrier = Event(name="barrier", client=client)
+
+            fut = client.compute(
+                memory_intensive_postprocessing(
+                    compute_intensive_barrier_task(
+                        memory_intensive_preprocessing(), ev_barrier
+                    )
+                )
+            )
+
+            # Scale up to maximum on preprocessing
+            client.wait_for_workers(n_workers=maximum, timeout=360)
+            assert len(cluster.observed) == maximum
+            assert adapt.log[-1][1]["status"] == "up"
+
+            # Scale down to a single worker on barrier task
+            start = time.monotonic()
+            while len(cluster.observed) > 1:
+                time.sleep(0.1)
+            end = time.monotonic()
+            assert len(cluster.observed) == 1
+            assert adapt.log[-1][1]["status"] == "down"
+            assert end - start < 420
+
+            ev_barrier.set()
+
+            # Scale up to maximum on postprocessing
+            client.wait_for_workers(n_workers=maximum, timeout=360)
+            assert len(cluster.observed) == maximum
+            assert adapt.log[-1][1]["status"] == "up"
+
+            wait(fut)
+            del fut
+
+            # Scale down to minimum
+            start = time.monotonic()
+            while len(cluster.observed) > minimum:
+                time.sleep(0.1)
+            end = time.monotonic()
+            assert len(cluster.observed) == minimum
+            assert adapt.log[-1][1]["status"] == "down"
+            assert end - start < 420

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -92,9 +92,7 @@ def test_adapt_to_changing_workload(minimum: int):
                     ev_barrier,
                     ev_final_fan_out,
                 ):
-                    fan_out = [
-                        clog(i, ev=ev_fan_out) for i in range(fan_out_size)
-                    ]
+                    fan_out = [clog(i, ev=ev_fan_out) for i in range(fan_out_size)]
                     barrier = clog(delayed(sum)(fan_out), ev=ev_barrier)
                     final_fan_out = [
                         clog(i, ev=ev_final_fan_out, barrier=barrier)

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -1,10 +1,10 @@
-import uuid
 import pytest
-from coiled.v2 import Cluster
-from dask.distributed import Client
-from distributed import Event
 import time
+import uuid
 
+import dask.array as da
+from coiled.v2 import Cluster
+from dask.distributed import Client, Event, Semaphore
 
 @pytest.mark.stability
 @pytest.mark.parametrize("minimum", (0, 1))
@@ -17,8 +17,8 @@ def test_scale_up_on_task_load(minimum, scatter):
     ) as cluster:
         with Client(cluster) as client:
             assert len(cluster.observed) == minimum
-            adapt = cluster.adapt(minimum=minimum, maximum=10, interval="5s", wait_count=3)
-            time.sleep(10)
+            adapt = cluster.adapt(minimum=minimum, maximum=10)
+            time.sleep(adapt.interval * 2.1) # Ensure enough time for system to adapt 
             assert len(adapt.log) == 0
             ev_fan_out = Event(name="fan-out", client=client)
 
@@ -39,3 +39,75 @@ def test_scale_up_on_task_load(minimum, scatter):
             ev_fan_out.set()
             client.gather(futures)
 
+
+@pytest.mark.stability
+@pytest.mark.parametrize("minimum", (0, 1))
+def test_adapt_to_changing_workload(minimum: int):
+    maximum = 20
+    fan_out_size = 100
+    with Cluster(
+        name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
+        n_workers=10,
+        worker_vm_types=["t3.medium"],
+    ) as cluster:
+        with Client(cluster) as client:
+            adapt = cluster.adapt(minimum=minimum, maximum=maximum)
+            assert len(adapt.log) == 0
+
+            def clog(x: int, ev: Event, sem: Semaphore, **kwargs) -> int:
+                # Ensure that no recomputation happens by decrementing a countdown on a semaphore
+                acquired = sem.acquire(timeout=0.1)
+                assert acquired is True
+                ev.wait()
+                return x
+
+            sem_fan_out = Semaphore(name="fan-out", max_leases=fan_out_size)
+            ev_fan_out = Event(name="fan-out", client=client)
+
+            fan_out = client.map(clog, range(fan_out_size), ev=ev_fan_out, sem=sem_fan_out)
+
+            reduction = client.submit(sum, fan_out)
+            sem_barrier = Semaphore(name="barrier", max_leases=1)
+            ev_barrier = Event(name="barrier", client=client)
+            barrier = client.submit(clog, reduction, ev=ev_barrier, sem=sem_barrier)
+            
+            sem_final_fan_out = Semaphore(name="final-fan-out", max_leases=fan_out_size)
+            ev_final_fan_out = Event(name="final-fan-out", client=client)
+            final_fan_out = client.map(clog, range(fan_out_size), ev=ev_final_fan_out, sem=sem_final_fan_out, barrier=barrier)
+
+            # Scale up to maximum
+            client.wait_for_workers(n_workers=maximum, timeout=300)
+            assert len(cluster.observed) == maximum
+            assert adapt.log[-1][1]["status"] == "up"
+
+            ev_fan_out.set()
+            # Scale down to a single worker
+            start = time.monotonic()
+            while len(cluster.observed) > 1:
+                time.sleep(0.1)
+            end = time.monotonic()
+            assert len(cluster.observed) == 1
+            assert adapt.log[-1][1]["status"] == "down"
+            # Do not take longer than 5 minutes to scale down
+            assert end - start < 300
+            
+            ev_barrier.set()
+            # Scale up to maximum again
+            client.wait_for_workers(n_workers=maximum, timeout=300)
+            while len(cluster.observed) < maximum:
+                time.sleep(0.1)
+            assert len(cluster.observed) == 20
+            assert adapt.log[-1][1]["status"] == "up"
+
+            ev_final_fan_out.set()
+            client.gather(final_fan_out)
+
+            # Scale down to minimum
+            start = time.monotonic()
+            while len(cluster.observed) > minimum:
+                time.sleep(0.1)
+            end = time.monotonic()
+            assert len(cluster.observed) == minimum
+            assert adapt.log[-1][1]["status"] == "down"
+            # Do not take longer than 5 minutes to scale down
+            assert end - start < 300

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -24,6 +24,7 @@ def test_scale_up_on_task_load(minimum, scatter):
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
         n_workers=minimum,
         worker_vm_types=["t3.medium"],
+        wait_for_workers=True,
     ) as cluster:
         with Client(cluster) as client:
             assert len(cluster.observed) == minimum
@@ -63,6 +64,7 @@ def test_adapt_to_changing_workload(minimum: int):
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
         n_workers=5,
         worker_vm_types=["t3.medium"],
+        wait_for_workers=True,
     ) as cluster:
         with Client(cluster) as client:
             adapt = cluster.adapt(minimum=minimum, maximum=maximum)
@@ -159,6 +161,7 @@ def test_adapt_to_memory_intensive_workload(minimum):
         name=f"test_adaptive_scaling-{uuid.uuid4().hex}",
         n_workers=minimum,
         worker_vm_types=["t3.medium"],
+        wait_for_workers=True,
     ) as cluster:
         with Client(cluster) as client:
             assert len(cluster.observed) == minimum

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -69,7 +69,7 @@ def test_adapt_to_changing_workload(minimum: int):
     maximum = 10
     fan_out_size = 100
     # Note: We set allowed-failures to ensure that no tasks are not retried upon ungraceful shutdown behavior
-    # during adative scaling but we receive a KilledWorker() instead.
+    # during adaptive scaling but we receive a KilledWorker() instead.
     with dask.config.set({"distributed.scheduler.allowed-failures": 0}):
         with Cluster(
             name=f"test_adaptive_scaling-{uuid.uuid4().hex}",

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -50,7 +50,7 @@ def test_scale_up_on_task_load(minimum, threshold):
             return duration
 
 
-@pytest.mark.stability
+@pytest.mark.skip(reason="coiled-runtime#266")
 @pytest.mark.stability
 def test_adapt_to_changing_workload():
     """Tests that adaptive scaling reacts within a reasonable amount of time to

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -231,8 +231,10 @@ def test_adapt_to_memory_intensive_workload(minimum, test_name_uuid):
         wait_for_workers=True,
         # Note: We set allowed-failures to ensure that no tasks are not retried upon ungraceful shutdown behavior
         # during adaptive scaling but we receive a KilledWorker() instead.
-        environ={"DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0",
-            "DASK_DISTRIBUTED__SCHEDULER__UNKNOWN_TASK_DURATION": "500ms",},
+        environ={
+            "DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0",
+            "DASK_DISTRIBUTED__SCHEDULER__UNKNOWN_TASK_DURATION": "500ms",
+        },
     ) as cluster:
         with Client(cluster) as client:
 

--- a/tests/stability/test_adaptive_scaling.py
+++ b/tests/stability/test_adaptive_scaling.py
@@ -168,7 +168,6 @@ def test_adapt_to_memory_intensive_workload(minimum):
         wait_for_workers=True,
     ) as cluster:
         with Client(cluster) as client:
-            assert len(cluster.observed) == minimum
             adapt = cluster.adapt(minimum=minimum, maximum=maximum)
             assert len(adapt.log) == 0
 


### PR DESCRIPTION
# PR Contents
* Closes: #134
* Blocked by: #306

This PR adds a suite of integration tests for adaptive scaling. Generally, these tests assert that the cluster scales up/down as desired and does so _quickly_ enough. For now, _quickly_ is quite loosely defined as scaling within a few minutes. We may want to iterate on this, but using the Coiled default settings, this appears to the closest bound we should use if we want the tests to pass reliably.

# Test Statistics

## General
**Measure:** Latency of scaling (up|down) from the point where the runnable tasks indicate that the cluster should scale.
**Sample size:** 10

## `test_scale_up_on_task_load`
| params | min (s) | max (s) | mean (s) | stdev |
|--------|-----|-----|-------|-------|
| [minimum=1, scatter=False] | 100.32 | 116.69 | 104.88 | 5.51 |
| [minimum=1, scatter=True] | 102.94 | 130.39 | 111.31 | 8.65 |
| [minimum=0, scatter=False] | 196.83 | 202.75 | 198.72 | 1.74 |

**[minimum=0, scatter=True]**
Fails with `TimeoutError: No valid workers found` due to dask/distributed#6686

**Note:**
Scaling up from an empty cluster takes ~2x as long as from a non-empty cluster. This is due to the fact that the cluster first spins up a single worker and only scales further once that is done.

## `test_adapt_to_changing_workload`
| params | measure | min (s) | max (s) | mean (s) | stdev |
|--------|----------|--------|-----|-------|-------|
| [minimum=0] | scale up from minimum | 97.21 | 106.66 | 100.84 | 3.16 |
| [minimum=0] | scale down to 1 | 295.82 | 300.14 | 298.11 | 1.69 |
| [minimum=0] | scale up from 1 | 101.69 | 117.10 | 106.17 | 4.68 |
| [minimum=0] | scale down to minimum | 296.30 | 300.05 | 298.14 | 1.39 |
| [minimum=1] | scale up from minimum | 101.02 | 110.23 | 106.46 | 2.89 |
| [minimum=1] | scale down to 1 | 296.59 | 314.44 | 299.90 | 5.26 |
| [minimum=1] | scale up from 1 | 110.89 | 189.64 | 125.23 | 24.20 |
| [minimum=1] | scale down to minimum | 295.37 | 299.81 | 297.32 | 1.41 |

**Note:**

Scaling down takes about 5 minutes (due to the `interval='5s'` and `wait_count=60`). IMO, while is is not snappy in terms of reaction time to changing workload patterns, it makes sense given the long startup time of containers. Essentially, we wait for about 3x the startup time before scaling down to smooth the pattern and avoid constantly firing up new containers if we over-reacted.

## `test_adapt_to_memory_intensive_workload`
**TL;DR:** This behavior of this test is very unreliable due to the long duration of scaling up, which leads to significant spilling and the workload slowing down tremendously or spilling workers getting OOM-killed.

**Note:**
Due to the long time it takes for this test to scale up, the first worker generates too much data in the beginning, leading to swapping and slowing down the processing. 

When running the memory-intensive task in isolation, it takes ~30 s on a cluster that consists of 10 workers. On an adaptive cluster that starts out with a single worker and can scale up to 10 workers, this becomes highly variable. If it finishes within 10 minutes, it appears to be due to an OOM error killing the worker that had spilled to disk. As a consequence, the data was reshuffled and workers were able to progress much faster.

Due to this, I would currently avoid testing that nothing gets recomputed. As things stand, recomputing tasks might be necessary to drive workloads over the finish line where workers spilled too much.