### PR TITLE
Generate dashboard more insistently

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -419,6 +419,7 @@ jobs:
 
   static-site:
     needs: process-results
+    # Always generate the site, as this can be skipped even if an indirect dependency fails (like a test run)
     if: always() && github.ref == 'refs/heads/main' && github.repository == 'coiled/coiled-runtime'
     name: Build static dashboards
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -419,6 +419,7 @@ jobs:
 
   static-site:
     needs: process-results
+    if: always() && github.ref == 'refs/heads/main' && github.repository == 'coiled/coiled-runtime'
     name: Build static dashboards
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The last step of this was skipped in the scheduled run yesterday, seemingly because of an upstream job failure (even though its actual dependency was successful). See [this SO](https://stackoverflow.com/questions/65735099/github-workflow-job-not-executed-even-when-job-needs-successful) discussion.