### PR TITLE
Make CI more robust to transient conda setup failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
+          condarc-file: ci/condarc
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
@@ -126,6 +127,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
+          condarc-file: ci/condarc
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
@@ -171,6 +173,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
+          condarc-file: ci/condarc
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
@@ -231,6 +234,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
+          condarc-file: ci/condarc
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 

--- a/ci/condarc
+++ b/ci/condarc
@@ -1,0 +1,6 @@
+channel_priority: strict
+auto_activate_base: false
+remote_backoff_factor: 20
+remote_connect_timeout_secs: 20.0
+remote_max_retries: 10
+remote_read_timeout_secs: 60.0


### PR DESCRIPTION
We've been observing some CI failures in `main` due to conda download timeouts. This PR increases related timeouts and retries (similar to what we're doing in `distributed`) to hopefully be more robust to these types of failures 

