### PR TITLE
Package Sync

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -326,11 +326,6 @@ jobs:
           python-version: "3.9"
           environment-file: ci/environment-dashboard.yml
 
-      - name: Download software environment assets
-        uses: actions/download-artifact@v3
-        with:
-          name: software-environment-py3.9
-
       - name: Generate dashboards
         run: python dashboard.py -d benchmark.db -o static -b coiled-latest-py3.9 coiled-upstream-py3.9 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,89 +22,6 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  software:
-    name: Setup
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Set up environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          use-mamba: true
-          condarc-file: ci/condarc
-          python-version: ${{ matrix.python-version }}
-          environment-file: ci/environment.yml
-
-      - name: Check upstream
-        run: |
-          if [[ ${{ github.event_name }} == "pull_request" ]]
-          then
-              export REF="HEAD^2"
-          else
-              export REF="HEAD"
-          fi
-
-          COMMIT="$(git log -n 1 --pretty=format:%s $REF)"
-          if [[ "$COMMIT" == *"test-upstream"* || ${{ github.event_name }} == "schedule" ]]
-          then
-            export TEST_UPSTREAM="true"
-          else
-            export TEST_UPSTREAM="false"
-          fi
-
-          # Put TEST_UPSTREAM into $GITHUB_ENV so it can be used in subsequent workflow steps
-          echo $TEST_UPSTREAM
-          echo TEST_UPSTREAM=$TEST_UPSTREAM >> $GITHUB_ENV
-
-          # Put TEST_UPSTREAM into a file so it can be downloaded in subsequent workflow jobs
-          echo $TEST_UPSTREAM > test_upstream.txt
-
-      - name: Build Coiled Software Environment
-        env:
-          DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
-        run: |
-          export PYTHON_VERSION_FORMATTED=$(echo "${{ matrix.python-version }}" | sed 's/\.//g' )
-          export REF_NAME_FORMATTED=$(echo "$GITHUB_REF_NAME" | sed 's/\./-/g' )
-          export COILED_SOFTWARE_NAME_HEAD=dask-engineering/coiled-runtime-${{ github.event_name }}
-          export COILED_SOFTWARE_NAME_TAIL=$GITHUB_RUN_ID-py$PYTHON_VERSION_FORMATTED
-
-          if [[ ${{ github.event_name }} = 'pull_request' ]]
-          then
-            export COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME_HEAD-${{ github.event.number }}-$COILED_SOFTWARE_NAME_TAIL
-          else
-            export COILED_SOFTWARE_NAME=$COILED_SOFTWARE_NAME_HEAD-$GITHUB_REF_TYPE-$REF_NAME_FORMATTED-$COILED_SOFTWARE_NAME_TAIL
-          fi
-
-          # Create conda environment.yaml file for the latest software environment
-          python ci/create_latest_runtime_meta.py
-          export ENV_FILE=latest.yaml
-          cat $ENV_FILE
-
-          mamba install coiled
-          echo "Creating Coiled software environment for $COILED_SOFTWARE_NAME"
-          coiled env create --name $COILED_SOFTWARE_NAME --conda $ENV_FILE
-
-          # Put COILED_SOFTWARE_NAME into a file so it can be downloaded in subsequent workflow jobs
-          echo $COILED_SOFTWARE_NAME > software_name.txt
-
-      - name: Upload environment file
-        uses: actions/upload-artifact@v3
-        with:
-          name: software-environment-py${{ matrix.python-version }}
-          path: |
-            latest.yaml
-            software_name.txt
-            test_upstream.txt
-
   runtime:
     name: Runtime - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
     needs: software
@@ -115,7 +32,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest", "0.0.3", "0.0.4"]
+        runtime-version: ["upstream", "latest", "0.0.3", "0.0.4"]
 
     steps:
       - uses: actions/checkout@v2
@@ -135,16 +52,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
-      - name: Download software environment assets
-        if: matrix.runtime-version == 'latest'
-        uses: actions/download-artifact@v3
-        with:
-          name: software-environment-py${{ matrix.python-version }}
-
       - name: Install coiled-runtime
         env:
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
-        run: source ci/scripts/install_coiled_runtime.sh
+        run: |
+          python ci/create_runtime_meta.py
+          source ci/scripts/install_coiled_runtime.sh
 
       - name: Run Coiled Runtime Tests
         id: test
@@ -173,7 +86,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
-        runtime-version: ["latest", "0.0.3", "0.0.4"]
+        runtime-version: ["upstream", "latest", "0.0.3", "0.0.4"]
 
     steps:
       - uses: actions/checkout@v2
@@ -193,16 +106,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
-      - name: Download software environment assets
-        if: matrix.runtime-version == 'latest'
-        uses: actions/download-artifact@v3
-        with:
-          name: software-environment-py${{ matrix.python-version }}
-
       - name: Install coiled-runtime
         env:
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
-        run: source ci/scripts/install_coiled_runtime.sh
+        run: |
+          python ci/create_runtime_meta.py
+          source ci/scripts/install_coiled_runtime.sh
 
       - name: Run benchmarking tests
         id: benchmarking_tests
@@ -231,7 +140,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]
-        runtime-version: ["latest", "0.0.3", "0.0.4"]
+        runtime-version: ["upstream", "latest", "0.0.3", "0.0.4"]
         include:
           - python-version: "3.9"
             runtime-version: "latest"
@@ -266,16 +175,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
-      - name: Download software environment assets
-        if: matrix.runtime-version == 'latest'
-        uses: actions/download-artifact@v3
-        with:
-          name: software-environment-py${{ matrix.python-version }}
-
       - name: Install coiled-runtime
         env:
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
-        run: source ci/scripts/install_coiled_runtime.sh
+        run: |
+          python ci/create_runtime_meta.py
+          source ci/scripts/install_coiled_runtime.sh
 
       - name: Run stability tests
         id: stability_tests
@@ -300,39 +205,6 @@ jobs:
         with:
           name: stability-${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}
           path: stability-${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
-
-  cleanup:
-    needs: [software, runtime, benchmarks, stability]
-    if: always()
-    name: Cleanup
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install coiled
-        run: python -m pip install coiled
-
-      - name: Download software environment assets
-        uses: actions/download-artifact@v3
-        with:
-          name: software-environment-py${{ matrix.python-version }}
-
-      - name: Remove Coiled software environment
-        env:
-          DASK_COILED__TOKEN: ${{ secrets.COILED_BENCHMARK_BOT_TOKEN }}
-        run: |
-          export SOFTWARE_NAME=$(cat software_name.txt)
-          echo "Deleting $SOFTWARE_NAME"
-          coiled env delete $SOFTWARE_NAME
 
   report:
     name: report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
   schedule:
     # Runs "At 00:01" (see https://crontab.guru)
@@ -396,7 +396,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-2  # this is needed for boto for some reason
+          AWS_DEFAULT_REGION: us-east-2 # this is needed for boto for some reason
           DB_NAME: benchmark.db
         run: |
           aws s3 cp s3://coiled-runtime-ci/benchmarks/$DB_NAME . || true
@@ -410,7 +410,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-2  # this is needed for boto for some reason
+          AWS_DEFAULT_REGION: us-east-2 # this is needed for boto for some reason
           DB_NAME: benchmark.db
         run: |
           aws s3 cp $DB_NAME s3://coiled-runtime-ci/benchmarks/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Upload benchmark results as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: benchmark.db
+          name: benchmark
           path: benchmark.db
 
   regressions:
@@ -259,7 +259,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: benchmark.db
+          name: benchmark
 
       - name: Set up environment
         uses: conda-incubator/setup-miniconda@v2
@@ -325,7 +325,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: benchmark.db
+          name: benchmark
 
       - name: Set up environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -315,7 +315,7 @@ jobs:
   static-site:
     needs: process-results
     # Always generate the site, as this can be skipped even if an indirect dependency fails (like a test run)
-    if: always() && github.ref == 'refs/heads/main' && github.repository == 'coiled/coiled-runtime'
+    if: always()
     name: Build static dashboards
     runs-on: ubuntu-latest
     steps:
@@ -339,7 +339,14 @@ jobs:
         run: |
           python dashboard.py
 
+      - name: Upload benchmark results as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: static-site
+          path: static/
+
       - name: Deploy 🚀
+        if: github.ref == 'refs/heads/main' && github.repository == 'coiled/coiled-runtime'
         uses: JamesIves/github-pages-deploy-action@4.1.7
         with:
           branch: gh-pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ defaults:
 jobs:
   runtime:
     name: Runtime - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
-    needs: software
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -78,7 +77,6 @@ jobs:
 
   benchmarks:
     name: Benchmarks - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
-    needs: software
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -132,7 +130,6 @@ jobs:
 
   stability:
     name: Stability - ${{ matrix.os }}, Python ${{ matrix.python-version }}, Runtime ${{ matrix.runtime-version }}
-    needs: software
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -335,12 +335,6 @@ jobs:
           name: static-dashboard
           path: static
 
-      - name: Upload benchmark results as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: static-site
-          path: static/
-
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.7
         if:  github.ref == 'refs/heads/main' && github.repository == 'coiled/coiled-runtime'

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ The `coiled-runtime` test suite can be run locally with the following steps:
    the Coiled Dask Engineering AWS S3 account.
 2. Create a Python environment and install development dependencies as
    specified in `ci/environment.yml`.
-3. (Optional) If testing against an unreleased version of `coiled-runtime`,
-   create a Coiled software environment with the unreleased `coiled-runtime` installed
-   and set a local `COILED_SOFTWARE_NAME` environment variable to the name
-   of the software environment (e.g. `export COILED_SOFTWARE_NAME="account/software-name"`)
+3. Install a coiled runtime environment. This might be from one of the environments
+   listed in ``environments/``, or it could be a development environment if you are
+   testing feature branches of dask or distributed. This test suite is configured
+   to run Coiled's ``package_sync`` feature, so your local environment should be copied
+   to the cluster.
 4. Run tests with `python -m pytest tests`
 
 Additionally, tests are automatically run on pull requests to this repository.

--- a/alembic/versions/2764a4f5582b_declare_bankruptcy_for_cluster_startup_.py
+++ b/alembic/versions/2764a4f5582b_declare_bankruptcy_for_cluster_startup_.py
@@ -1,0 +1,30 @@
+"""Declare bankruptcy for cluster startup time
+
+Revision ID: 2764a4f5582b
+Revises: 924e9b1430e1
+Create Date: 2022-09-14 11:45:46.024184
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2764a4f5582b"
+down_revision = "924e9b1430e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        delete from test_run
+        where originalname = 'test_default_cluster_spinup_time'
+        and path = 'benchmarks/test_coiled.py';
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/ci/create_runtime_meta.py
+++ b/ci/create_runtime_meta.py
@@ -47,7 +47,7 @@ def main():
             {
                 "pip": [
                     "git+https://github.com/dask/dask@main",
-                    "git+https://github.com/dask/distributed@817ead3aed90bad8c6bd38063ec8bdfcacb4ff5f",
+                    "git+https://github.com/dask/distributed@main",
                 ]
             }
         )

--- a/ci/create_runtime_meta.py
+++ b/ci/create_runtime_meta.py
@@ -47,7 +47,7 @@ def main():
             {
                 "pip": [
                     "git+https://github.com/dask/dask@main",
-                    "git+https://github.com/dask/distributed@main",
+                    "git+https://github.com/dask/distributed@817ead3aed90bad8c6bd38063ec8bdfcacb4ff5f",
                 ]
             }
         )

--- a/ci/create_runtime_meta.py
+++ b/ci/create_runtime_meta.py
@@ -6,7 +6,6 @@ import pathlib
 import shlex
 import subprocess
 import sys
-from distutils.util import strtobool
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -40,8 +39,7 @@ def main():
 
     # Optionally use the development version of `dask` and `distributed`
     # from `dask/label/dev` conda channel
-    upstream = strtobool(os.environ.get("TEST_UPSTREAM", "false"))
-    if upstream:
+    if os.environ.get("COILED_RUNTIME_VERSION", "unknown") == "upstream":
         upstream_packages = {"dask", "distributed"}
         for idx, req in enumerate(requirements):
             package_name = Requirement(req).name
@@ -53,7 +51,7 @@ def main():
         "channels": ["conda-forge"],
         "dependencies": requirements,
     }
-    with open("latest.yaml", "w") as f:
+    with open("runtime.yaml", "w") as f:
         yaml.dump(env, f)
 
 

--- a/ci/scripts/combine-dbs.sh
+++ b/ci/scripts/combine-dbs.sh
@@ -16,6 +16,11 @@ DB_NAME=benchmark.tmp.db alembic upgrade head
 # Merge in the individual job dbs into our working copy
 for FILE in $(find benchmarks -name "*.db")
 do
+  # Skip the output DB if we see it
+  if [ ${FILE##*/} == $DB_NAME ]; then
+    echo "Skipping $FILE"
+    continue
+  fi
   echo "Processing $FILE"
   # Copy the individual table into the primary one. We make an intermediate
   # temp table so that we can null out the primary keys and reset the

--- a/ci/scripts/install_coiled_runtime.sh
+++ b/ci/scripts/install_coiled_runtime.sh
@@ -5,10 +5,10 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
-if [[ "$COILED_RUNTIME_VERSION" = 'latest' ]]
+if [[ "$COILED_RUNTIME_VERSION" = 'latest' || "$COILED_RUNTIME_VERSION" = 'upstream' ]]
 then
-  cat latest.yaml
-  mamba env update --file latest.yaml
+  cat runtime.yaml
+  mamba env update --file runtime.yaml
 else
   mamba install -c conda-forge coiled-runtime=$COILED_RUNTIME_VERSION
 fi

--- a/ci/scripts/run_tests.sh
+++ b/ci/scripts/run_tests.sh
@@ -5,14 +5,11 @@ set -o xtrace
 BENCHMARK="${BENCHMARK:-false}"
 
 # Ensure we run additional tests when testing the latest coiled-runtime
-if [[ $COILED_RUNTIME_VERSION = 'latest' ]]
+if [[ $COILED_RUNTIME_VERSION = 'latest' || $COILED_RUNTIME_VERSION = 'upstream' ]]
 then
   EXTRA_OPTIONS="--run-latest"
-  export COILED_SOFTWARE_NAME=$(cat software_name.txt)
-  export TEST_UPSTREAM=$(cat test_upstream.txt)
 else
   EXTRA_OPTIONS=""
-  unset COILED_SOFTWARE_NAME
 fi
 if [[ $BENCHMARK = 'true' ]]
 then

--- a/conftest.py
+++ b/conftest.py
@@ -262,8 +262,8 @@ def small_cluster(request):
     with Cluster(
         name=f"{module}-{uuid.uuid4().hex[:8]}",
         n_workers=10,
-        worker_vm_types=["t3.xlarge"],  # 4CPU, 16GiB
-        scheduler_vm_types=["t3.xlarge"],
+        worker_vm_types=["t3.large"],  # 2CPU, 8GiB
+        scheduler_vm_types=["t3.large"],
         backend_options=backend_options,
         package_sync=True,
     ) as cluster:

--- a/conftest.py
+++ b/conftest.py
@@ -262,8 +262,8 @@ def small_cluster(request):
     with Cluster(
         name=f"{module}-{uuid.uuid4().hex[:8]}",
         n_workers=10,
-        worker_vm_types=["t3.large"],  # 2CPU, 8GiB
-        scheduler_vm_types=["t3.large"],
+        worker_vm_types=["t3.xlarge"],  # 4CPU, 16GiB
+        scheduler_vm_types=["t3.xlarge"],
         backend_options=backend_options,
         package_sync=True,
     ) as cluster:

--- a/conftest.py
+++ b/conftest.py
@@ -103,7 +103,7 @@ def get_coiled_software_name():
 dask.config.set(
     {
         "coiled.account": "dask-engineering",
-        "coiled.software": get_coiled_software_name(),
+        # "coiled.software": get_coiled_software_name(),
     }
 )
 
@@ -259,6 +259,7 @@ def small_cluster(request):
         worker_vm_types=["t3.large"],
         scheduler_vm_types=["t3.large"],
         backend_options=backend_options,
+        package_sync=True,
     ) as cluster:
         yield cluster
 

--- a/tests/benchmarks/test_coiled.py
+++ b/tests/benchmarks/test_coiled.py
@@ -5,5 +5,7 @@ from coiled import Cluster
 
 def test_default_cluster_spinup_time(request, auto_benchmark_time):
 
-    with Cluster(name=f"{request.node.originalname}-{uuid.uuid4().hex[:8]}"):
+    with Cluster(
+        name=f"{request.node.originalname}-{uuid.uuid4().hex[:8]}", package_sync=True
+    ):
         pass

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -21,6 +21,7 @@ def parquet_cluster():
         n_workers=N_WORKERS,
         worker_vm_types=["m5.xlarge"],
         scheduler_vm_types=["m5.xlarge"],
+        package_sync=True,
     ) as cluster:
         yield cluster
 

--- a/tests/runtime/test_build.py
+++ b/tests/runtime/test_build.py
@@ -75,7 +75,7 @@ def test_install_dist():
     # Test that versions of packages installed are consistent with those
     # specified in `meta.yaml`
 
-    if os.environ.get("COILED_RUNTIME_VERSION", "unknown") not in (
+    if os.environ.get("COILED_RUNTIME_VERSION", "unknown") in (
         "upstream",
         "latest",
         "unknown",

--- a/tests/runtime/test_build.py
+++ b/tests/runtime/test_build.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess
 import sys
 
+import coiled
 import pytest
 import yaml
 from distributed import Client

--- a/tests/runtime/test_build.py
+++ b/tests/runtime/test_build.py
@@ -7,10 +7,7 @@ import pathlib
 import shlex
 import subprocess
 import sys
-from distutils.util import strtobool
 
-import coiled
-import dask
 import pytest
 import yaml
 from distributed import Client
@@ -77,8 +74,10 @@ def test_install_dist():
     # Test that versions of packages installed are consistent with those
     # specified in `meta.yaml`
 
-    if Version(dask.__version__).local or strtobool(
-        os.environ.get("TEST_UPSTREAM", "false")
+    if os.environ.get("COILED_RUNTIME_VERSION", "unknown") not in (
+        "upstream",
+        "latest",
+        "unknown",
     ):
         pytest.skip("Not valid on upstream build")
 

--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -18,6 +18,7 @@ def test_repeated_merge_spill(upload_cluster_dump, benchmark_time):
         name=f"test_deadlock-{uuid.uuid4().hex}",
         n_workers=20,
         worker_vm_types=["t3.medium"],
+        package_sync=True,
     ) as cluster:
         with Client(cluster) as client:
             with upload_cluster_dump(client, cluster), benchmark_time:

--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -17,7 +17,8 @@ def test_repeated_merge_spill(upload_cluster_dump, benchmark_time):
     with coiled.v2.Cluster(
         name=f"test_deadlock-{uuid.uuid4().hex}",
         n_workers=20,
-        worker_vm_types=["t3.medium"],
+        worker_vm_types=["t3.large"],
+        scheduler_vm_types=["t3.large"],
         package_sync=True,
     ) as cluster:
         with Client(cluster) as client:

--- a/tests/stability/test_shuffle.py
+++ b/tests/stability/test_shuffle.py
@@ -32,4 +32,10 @@ def test_shuffle_parquet(small_client, s3_url, s3_storage_options):
     shuffled_url = s3_url + "/shuffled.parquet"
     df_shuffled = dd.read_parquet(dataset_url, storage_options=s3_storage_options)
     df_shuffled = df_shuffled.shuffle(on="x")
-    df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)
+    # Workaround for performance issue. See https://github.com/coiled/coiled-runtime/issues/79
+    # for more details. Replace with the line below once using `dask>=2022.04.2`.
+    # df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)
+    result = df_shuffled.to_parquet(
+        shuffled_url, compute=False, storage_options=s3_storage_options
+    )
+    dask.compute(result)

--- a/tests/stability/test_shuffle.py
+++ b/tests/stability/test_shuffle.py
@@ -32,10 +32,4 @@ def test_shuffle_parquet(small_client, s3_url, s3_storage_options):
     shuffled_url = s3_url + "/shuffled.parquet"
     df_shuffled = dd.read_parquet(dataset_url, storage_options=s3_storage_options)
     df_shuffled = df_shuffled.shuffle(on="x")
-    # Workaround for performance issue. See https://github.com/coiled/coiled-runtime/issues/79
-    # for more details. Replace with the line below once using `dask>=2022.04.2`.
-    # df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)
-    result = df_shuffled.to_parquet(
-        shuffled_url, compute=False, storage_options=s3_storage_options
-    )
-    dask.compute(result)
+    df_shuffled.to_parquet(shuffled_url, storage_options=s3_storage_options)

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -12,9 +12,9 @@ def spill_cluster():
         f"spill-{uuid.uuid4().hex[:8]}",
         n_workers=5,
         package_sync=True,
-        worker_disk_size=64,
-        worker_vm_types=["m5d.large"],
-        scheduler_vm_types=["m5d.large"],
+        worker_disk_size=55,
+        worker_vm_types=["t3.large"],
+        scheduler_vm_types=["t3.large"],
         wait_for_workers=True,
         environ={
             # Note: We set allowed-failures to ensure that no tasks are not retried

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -32,12 +32,14 @@ def spill_cluster():
 
 
 @pytest.fixture
-def spill_client(spill_cluster, sample_memory, benchmark_time):
+def spill_client(
+    spill_cluster, benchmark_task_durations, benchmark_memory, benchmark_time
+):
     with Client(spill_cluster) as client:
         spill_cluster.scale(5)
         client.wait_for_workers(5)
         client.restart()
-        with sample_memory(client), benchmark_time:
+        with benchmark_memory(client), benchmark_task_durations(client), benchmark_time:
             yield client
 
 

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -13,7 +13,8 @@ def spill_cluster():
         n_workers=5,
         package_sync=True,
         worker_disk_size=55,
-        worker_vm_types=["t3.medium"],
+        worker_vm_types=["t3.large"],
+        scheduler_vm_types=["t3.large"],
         wait_for_workers=True,
         environ={
             # Note: We set allowed-failures to ensure that no tasks are not retried

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -12,7 +12,7 @@ def spill_cluster():
         f"spill-{uuid.uuid4().hex[:8]}",
         n_workers=5,
         package_sync=True,
-        worker_disk_size=55,
+        worker_disk_size=64,
         worker_vm_types=["t3.large"],
         scheduler_vm_types=["t3.large"],
         wait_for_workers=True,
@@ -46,7 +46,7 @@ def spill_client(
 @pytest.mark.stability
 @pytest.mark.parametrize("keep_around", (True, False))
 def test_spilling(spill_client, keep_around):
-    arr = da.random.random((200, 2**27)).persist()  # 200 GiB
+    arr = da.random.random((64, 2**27)).persist()  # 64 GiB, ~2x memory
     wait(arr)
     fut = spill_client.compute(arr.sum())
     if not keep_around:

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -41,7 +41,6 @@ def spill_client(spill_cluster, sample_memory, benchmark_time):
             yield client
 
 
-@pytest.mark.skip(reason="https://github.com/coiled/coiled-runtime/issues/280")
 @pytest.mark.stability
 @pytest.mark.parametrize("keep_around", (True, False))
 def test_spilling(spill_client, keep_around):

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -40,6 +40,7 @@ def spill_client(spill_cluster, sample_memory, benchmark_time):
             yield client
 
 
+@pytest.mark.skip(reason="https://github.com/coiled/coiled-runtime/issues/280")
 @pytest.mark.stability
 @pytest.mark.parametrize("keep_around", (True, False))
 def test_spilling(spill_client, keep_around):

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -6,39 +6,12 @@ from coiled.v2 import Cluster
 from dask.distributed import Client, wait
 
 
-@pytest.mark.stability
-@pytest.mark.parametrize("keep_around", (True, False))
-def test_spilling(keep_around):
+@pytest.fixture(scope="module")
+def spill_cluster():
     with Cluster(
-        name=f"test_spill-{uuid.uuid4().hex}",
+        f"spill-{uuid.uuid4().hex[:8]}",
         n_workers=5,
-        worker_disk_size=55,
-        worker_vm_types=["t3.medium"],
-        wait_for_workers=True,
-        environ={
-            # Note: We set allowed-failures to ensure that no tasks are not retried
-            #  upon ungraceful shutdown behavior during adaptive scaling
-            #  but we receive a KilledWorker() instead.
-            "DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0"
-        },
-    ) as cluster:
-        with Client(cluster) as client:
-            arr = da.random.random((200, 2**27)).persist()  # 200 GiB
-            wait(arr)
-            fut = client.compute(arr.sum())
-            if not keep_around:
-                del arr
-            wait(fut)
-
-
-@pytest.mark.skip(
-    reason="Skip until https://github.com/coiled/feedback/issues/185 is resolved."
-)
-@pytest.mark.stability
-def test_tensordot_stress():
-    with Cluster(
-        name=f"test_spill-{uuid.uuid4().hex}",
-        n_workers=5,
+        package_sync=True,
         worker_disk_size=55,
         worker_vm_types=["t3.medium"],
         wait_for_workers=True,
@@ -54,9 +27,37 @@ def test_tensordot_stress():
             "DASK_DISTRIBUTED__WORKER__CONNECTIONS__OUTGOING": "1",
         },
     ) as cluster:
-        with Client(cluster) as client:
-            a = da.random.random((48 * 1024, 48 * 1024))  # 18 GiB
-            b = (a @ a.T).sum().round(3)
-            fut = client.compute(b)
-            wait(fut)
-            assert fut.result()
+        yield cluster
+
+
+@pytest.fixture
+def spill_client(spill_cluster, sample_memory, benchmark_time):
+    with Client(spill_cluster) as client:
+        spill_cluster.scale(5)
+        client.wait_for_workers(5)
+        client.restart()
+        with sample_memory(client), benchmark_time:
+            yield client
+
+
+@pytest.mark.stability
+@pytest.mark.parametrize("keep_around", (True, False))
+def test_spilling(spill_client, keep_around):
+    arr = da.random.random((200, 2**27)).persist()  # 200 GiB
+    wait(arr)
+    fut = spill_client.compute(arr.sum())
+    if not keep_around:
+        del arr
+    wait(fut)
+
+
+@pytest.mark.skip(
+    reason="Skip until https://github.com/coiled/feedback/issues/185 is resolved."
+)
+@pytest.mark.stability
+def test_tensordot_stress(spill_client):
+    a = da.random.random((48 * 1024, 48 * 1024))  # 18 GiB
+    b = (a @ a.T).sum().round(3)
+    fut = spill_client.compute(b)
+    wait(fut)
+    assert fut.result()

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -12,9 +12,9 @@ def spill_cluster():
         f"spill-{uuid.uuid4().hex[:8]}",
         n_workers=5,
         package_sync=True,
-        worker_disk_size=55,
-        worker_vm_types=["t3.large"],
-        scheduler_vm_types=["t3.large"],
+        worker_disk_size=64,
+        worker_vm_types=["m5d.large"],
+        scheduler_vm_types=["m5d.large"],
         wait_for_workers=True,
         environ={
             # Note: We set allowed-failures to ensure that no tasks are not retried


### PR DESCRIPTION
Pushing #222 a bit further to see if anything breaks. This

1. Removes a couple of controlling environment variables, which should simplify local development as well as CI workflows. Specifically `TEST_UPSTREAM` has been folded into `COILED_RUNTIME_VERSION`, which can be a version number, "upstream", or "latest", and `COILED_SOFTWARE_VERSION` is no longer necessary in a `package_sync` universe.
2. Removes the setup/cleanup jobs. This also means there are fewer artifacts passed around between jobs, which is nice.
3. "upstream" is now run on pull requests