### PR TITLE
Remove strict priority

### DIFF
--- a/ci/condarc
+++ b/ci/condarc
@@ -1,4 +1,3 @@
-channel_priority: strict
 auto_activate_base: false
 remote_backoff_factor: 20
 remote_connect_timeout_secs: 20.0


### PR DESCRIPTION
Attempt at fixing #236.  Strict priority seemingly doesn't work for direct URLs to nightly conda builds