### PR TITLE
More specific time benchmarking

### DIFF
--- a/tests/benchmarks/test_coiled.py
+++ b/tests/benchmarks/test_coiled.py
@@ -3,7 +3,7 @@ import uuid
 from coiled import Cluster
 
 
-def test_default_cluster_spinup_time(request):
+def test_default_cluster_spinup_time(request, auto_benchmark_time):
 
     with Cluster(name=f"{request.node.originalname}-{uuid.uuid4().hex[:8]}"):
         pass

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -26,12 +26,12 @@ def parquet_cluster():
 
 
 @pytest.fixture
-def parquet_client(parquet_cluster, sample_memory):
+def parquet_client(parquet_cluster, sample_memory, benchmark_time):
     with distributed.Client(parquet_cluster) as client:
         parquet_cluster.scale(N_WORKERS)
         client.wait_for_workers(N_WORKERS)
         client.restart()
-        with sample_memory(client):
+        with sample_memory(client), benchmark_time:
             yield client
 
 

--- a/tests/runtime/test_build.py
+++ b/tests/runtime/test_build.py
@@ -18,6 +18,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from packaging.requirements import Requirement, SpecifierSet
 from packaging.version import Version
 
+# Note: all of these tests are local, and do not create clusters,
+# so don't bother benchmarking them.
+
 
 def get_installed_versions(packages) -> dict[str, str]:
     package_versions = {}

--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -13,14 +13,14 @@ from distributed import Client, wait
 @pytest.mark.skip(
     reason="Skip until https://github.com/dask/distributed/pull/6637 is merged"
 )
-def test_repeated_merge_spill(upload_cluster_dump):
+def test_repeated_merge_spill(upload_cluster_dump, benchmark_time):
     with coiled.v2.Cluster(
         name=f"test_deadlock-{uuid.uuid4().hex}",
         n_workers=20,
         worker_vm_types=["t3.medium"],
     ) as cluster:
         with Client(cluster) as client:
-            with upload_cluster_dump(client, cluster):
+            with upload_cluster_dump(client, cluster), benchmark_time:
                 ddf = dask.datasets.timeseries(
                     "2020",
                     "2025",


### PR DESCRIPTION
Fixes #238 

Create a `benchmark_time` contextmanager fixture for more granular benchmarking of tests when desired. The old behavior is available through `auto_benchmark_time`. The fixture is no longer autoused throughout the whole test suite to allow for custom usage, though I have applied it to `small_client` and `parquet_client` so those should continue working.