### PR TITLE
Fix static site gen

### DIFF
--- a/ci/environment-dashboard.yml
+++ b/ci/environment-dashboard.yml
@@ -9,6 +9,8 @@ dependencies:
   - panel=0.13
   - coiled
   - dask
+  - dask-ml
   - distributed
+  - xgboost
   - pandas
   - tabulate

--- a/dashboard.py
+++ b/dashboard.py
@@ -35,7 +35,7 @@ def get_test_source():
                     if not callable(fn):
                         continue
                     source[f[len("tests/") :] + "::" + test] = inspect.getsource(fn)
-        except Exception:
+        except BaseException:  # Some pytest exceptions inherit directly from BaseException
             pass
     return source
 


### PR DESCRIPTION
Handle BaseExceptions in dashboard generation, include xgboost and dask-ml in dashboard env

Fixes #244. No matter how careful you think you are being, somebody comes along and inherits from `BaseException`.