### PR TITLE
Build `coiled-runtime=0.1.0` software environments

### DIFF
--- a/.github/workflows/software-environments-stable.yml
+++ b/.github/workflows/software-environments-stable.yml
@@ -15,20 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        runtime-version: ["0.0.3", "0.0.4"]
+        runtime-version: ["0.0.4", "0.1.0"]
         server: ["https://cloud.coiled.io", "https://staging.coiledhq.com"]
         include:
           - server: "https://cloud.coiled.io"
             token-name: COILED_BENCHMARK_BOT_TOKEN
           - server: "https://staging.coiledhq.com"
             token-name: COILED_STAGING_BENCHMARK_BOT_TOKEN
-          - python-version: "3.7"
-            runtime-version: "0.0.3"
-        exclude:
-          # `coiled-runtime=0.0.3` pins to a version of Dask
-          # that doesn't support Python 3.10
-          - python-version: "3.10"
-            runtime-version: "0.0.3"
 
     steps:
       - name: Checkout source

--- a/environments/coiled-runtime-0-1-0-py310.yml
+++ b/environments/coiled-runtime-0-1-0-py310.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+    - python=3.10
+    - coiled-runtime=0.1.0

--- a/environments/coiled-runtime-0-1-0-py38.yml
+++ b/environments/coiled-runtime-0-1-0-py38.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+    - python=3.8
+    - coiled-runtime=0.1.0

--- a/environments/coiled-runtime-0-1-0-py39.yml
+++ b/environments/coiled-runtime-0-1-0-py39.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+    - python=3.9
+    - coiled-runtime=0.1.0


### PR DESCRIPTION
Creates new Coiled software environments that use the fresh `coiled-runtime=0.1.0` release