### PR TITLE
Add pynvml to recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,10 +46,12 @@ requirements:
     - tornado ==6.1
     - toolz ==0.11.2
     - python-blosc ==1.10.2
+
     - zict ==2.2.0
     - xgboost ==1.6.1
     - dask-ml ==2022.5.27
     - openssl >1.1.0g
+    - pynmvl ==11.4.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,12 +46,11 @@ requirements:
     - tornado ==6.1
     - toolz ==0.11.2
     - python-blosc ==1.10.2
-
     - zict ==2.2.0
     - xgboost ==1.6.1
     - dask-ml ==2022.5.27
     - openssl >1.1.0g
-    - pynmvl ==11.4.1
+    - pynvml ==11.4.1
 
 test:
   imports:


### PR DESCRIPTION
This package is required for the dask dashboard to properly
monitor GPU usage. The pinned version is the latest release
on github (dated 2021-12-08).

Closes #255 