### PR TITLE
Factor out cluster and client

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+
+from coiled import Cluster
+from distributed import Client
+
+
+@contextlib.contextmanager
+def small_cluster(
+    backend_options=None,
+    module=None,
+):
+
+    with Cluster(
+        name=f"{module}-{uuid.uuid4().hex[:8]}",
+        n_workers=10,
+        worker_vm_types=["t3.large"],  # 2CPU, 8GiB
+        scheduler_vm_types=["t3.large"],
+        backend_options=backend_options,
+    ) as cluster:
+        yield cluster
+
+
+@contextlib.contextmanager
+def small_client(
+    cluster=None,
+    backend_options=None,
+    module=None,
+):
+    stack = contextlib.ExitStack()
+    if not cluster:
+        cluster = stack.enter_context(small_cluster(backend_options, module))
+
+    client = stack.enter_context(Client(cluster))
+    with stack:
+        cluster.scale(10)
+        client.wait_for_workers(10)
+        client.restart()
+        yield client

--- a/utils.py
+++ b/utils.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import contextlib
 import uuid
 
-from coiled import Cluster
+from coiled import AWSOptions, Cluster
 from distributed import Client
 
 
 @contextlib.contextmanager
 def small_cluster(
-    backend_options=None,
-    module=None,
+    backend_options: AWSOptions | None = None,
+    module: str = "manual",
 ):
+    if backend_options is None:
+        backend_options = {"spot": True, "spot_on_demand_fallback": True}
 
     with Cluster(
         name=f"{module}-{uuid.uuid4().hex[:8]}",
@@ -26,8 +28,8 @@ def small_cluster(
 @contextlib.contextmanager
 def small_client(
     cluster=None,
-    backend_options=None,
-    module=None,
+    backend_options: AWSOptions | None = None,
+    module: str = "manual",
 ):
     stack = contextlib.ExitStack()
     if not cluster:


### PR DESCRIPTION
I'm currently rerunning a couple of our benchmarks and am trying to inspect the cluster mid-flight / after the benchmark. Within pytest, this is a bit awkward. I can insert breakpoints, etc. but the experience is not nice.

I could move / copy the entire test code to a jupyter notebook and gain much more flexibility. To stay as close to the original it would be nice if we exported the standard functions as ctxmanagers or similar.

This is an example of how we could do this. Thoughts?