### PR TITLE
Patch release 0.1.1 - bump dask and distributed to 2022.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ not a personal fork**.
 
 To issue a new `coiled-runtime` release:
 
-1. Locally update the `coiled-runtime` version and package pinnings specified in `recipe/meta.yaml`.
+1. Locally update the `coiled-runtime` version and package pinnings specified in `recipe/meta.yaml` and `setup.py`.
     - When updating package version pinnings (in particular `dask` and `distributed`)
       confirm there are no reported large scale stability issues (e.g. deadlocks) or
       performance regressions on the `dask` / `distributed` issue trackers or offline
@@ -192,6 +192,14 @@ git push origin main --tags
     - Reset the build number back to `0` if it isn't already.
     - For more information on updating conda-forge packages, see the
       [conda-forge docs](https://conda-forge.org/docs/maintainer/updating_pkgs.html).
+
+6. Upload to PyPI
+
+```
+git clean -xfd
+python setup.py sdist bdist_wheel
+twine upload dist/*
+```
 
 ## License
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "coiled-runtime" %}
 {% set version = "0.1.1" + environ.get("VERSION_SUFFIX", '') %}
-{% set dask_version = environ.get("DASK_VERSION", "2022.6.0") %}
-{% set distributed_version = environ.get("DISTRIBUTED_VERSION", "2022.6.0") %}
+{% set dask_version = environ.get("DASK_VERSION", "2022.6.1") %}
+{% set distributed_version = environ.get("DISTRIBUTED_VERSION", "2022.6.1") %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ python_requires, install_requires = get_requirements()
 
 setup(
     name="coiled-runtime",
-    version="0.1.0",
+    version="0.1.1",
     description="Simple and fast way to get started with Dask",
     url="https://github.com/coiled/coiled-runtime",
     license="BSD",


### PR DESCRIPTION
PR to get started patch release - see issue #306

I added instructions for PyPI release too, not sure if there is another step here, please take a look in case I forgot something. 