### PR TITLE
Fix spark flavored parquet test

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ git add alembic/versions/name_of_new_migration.py
 git commit -m "Bankruptcy migration for <test-name>"
 ```
 
-An example of a migration that does this is [./alembic/versions/924e9b1430e1_spark_test_bankruptcy.py](here).
+An example of a migration that does this is [here](./alembic/versions/924e9b1430e1_spark_test_bankruptcy.py).
 
 ### Using the benchmark fixtures
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ git commit -m "Added a new migration"
 
 Migrations are automatically applied in the pytest runs, so you needn't run them yourself.
 
+### Deleting old test data
+
+At times you might change a specific test that makes older benchmarking data irrelevant.
+In that case, you can discard old benchmarking data for that test by applying a data migration
+removing that data:
+
+```bash
+alembic revision -m "Declare bankruptcy for <test-name>"
+# Edit the migration here to do what you want.
+git add alembic/versions/name_of_new_migration.py
+git commit -m "Bankruptcy migration for <test-name>"
+```
+
+An example of a migration that does this is [./alembic/versions/924e9b1430e1_spark_test_bankruptcy.py](here).
+
 ### Using the benchmark fixtures
 
 We have a number of pytest fixtures defined which can be used to automatically track certain metrics in the benchmark database.
@@ -141,6 +156,9 @@ def test_something(benchmark_task_durations):
         with benchmark_task_durations(client):
             client.submit(expensive_function)
 ```
+
+**`benchmark_all`**: This convenience fixture yields a context manager which takes a distributed `Client` object,
+and combines `benchmark_time`, `benchmark_task_durations`, and `benchmark_memory` into a single fixture.
 
 Writing a new benchmark fixture would generally look like:
 1. Requesting the `test_run_benchmark` fixture, which yields an ORM object.

--- a/alembic/versions/924e9b1430e1_spark_test_bankruptcy.py
+++ b/alembic/versions/924e9b1430e1_spark_test_bankruptcy.py
@@ -1,0 +1,30 @@
+"""spark test bankruptcy
+
+Revision ID: 924e9b1430e1
+Revises: 7d7844fca7cf
+Create Date: 2022-09-12 09:49:32.494687
+
+"""
+from alembic import op
+from sqlalchemy.sql import delete, table
+
+
+# revision identifiers, used by Alembic.
+revision = "924e9b1430e1"
+down_revision = "7d7844fca7cf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        delete from test_run
+        where originalname = 'test_read_spark_generated_data'
+        and path = 'benchmarks/test_parquet.py';
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/924e9b1430e1_spark_test_bankruptcy.py
+++ b/alembic/versions/924e9b1430e1_spark_test_bankruptcy.py
@@ -6,7 +6,6 @@ Create Date: 2022-09-12 09:49:32.494687
 
 """
 from alembic import op
-from sqlalchemy.sql import delete, table
 
 
 # revision identifiers, used by Alembic.

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -47,7 +47,7 @@ def test_read_spark_generated_data(parquet_client):
     Citation: https://www.nature.com/articles/s41467-018-08148-z
     """
     ddf = dd.read_parquet(
-        "s3://coiled-runtime-ci/thousandgenomes_dragen/var_partby_samples/NA21**.parquet",
+        "s3://coiled-runtime-ci/thousandgenomes_dagen/NA21**.parquet",
         engine="pyarrow",
         index="sample_id",
     )


### PR DESCRIPTION
This was a silly mistake on my part due to not updating a path when the data location changed. But I'm using this as an opportunity to document how one might delete old, irrelevant data.