### PR TITLE
Comment out worker-saturation in AB_sample.dask

### DIFF
--- a/AB_environments/AB_sample.dask.yaml.rename_me
+++ b/AB_environments/AB_sample.dask.yaml.rename_me
@@ -3,6 +3,6 @@
 # All files *must* be called AB_<name>.conda.yaml
 # and *must* be accompanied by AB_<name>.dask.yaml.
 # Leave empty if you don't want to override anything.
-distributed:
-  scheduler:
-    worker-saturation: 1.2
+# distributed:
+#   scheduler:
+#     worker-saturation: 1.2


### PR DESCRIPTION
I think it's easy to forget about this if you only care about a commit but not any config changes. Already happened over in https://github.com/dask/distributed/pull/7024

Let's keep it as an example