### PR TITLE
Workers may not be online when Cluster(wait_for_workers=True) returns

### DIFF
--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -34,6 +34,8 @@ def test_work_stealing_on_scaling_up(
         package_sync=True,
     ) as cluster:
         with Client(cluster) as client:
+            # FIXME https://github.com/coiled/platform/issues/103
+            client.wait_for_workers(1)
             with upload_cluster_dump(client, cluster), benchmark_all(client):
                 # Slow task.
                 def func1(chunk):
@@ -87,6 +89,8 @@ def test_work_stealing_on_straggling_worker(
         wait_for_workers=True,
     ) as cluster:
         with Client(cluster) as client:
+            # FIXME https://github.com/coiled/platform/issues/103
+            client.wait_for_workers(10)
             with upload_cluster_dump(client, cluster), benchmark_all(client):
 
                 def clog():


### PR DESCRIPTION
- Work around https://github.com/coiled/platform/issues/103