### PR TITLE
Move `test_default_cluster_spinup_time` to its own module

### DIFF
--- a/tests/runtime/test_cluster_creation.py
+++ b/tests/runtime/test_cluster_creation.py
@@ -1,0 +1,15 @@
+import uuid
+
+from coiled import Cluster
+
+
+def test_default_cluster_spinup_time(request, auto_benchmark_time):
+    """Note: this test must be kept in a separate module from the tests that use the
+    small_cluster fixture (which has the scope=module) or its child small_client.
+    This prevents having the small_cluster sitting idle for 5+ minutes while this test
+    is running.
+    """
+    with Cluster(
+        name=f"{request.node.originalname}-{uuid.uuid4().hex[:8]}", package_sync=True
+    ):
+        pass

--- a/tests/runtime/test_coiled.py
+++ b/tests/runtime/test_coiled.py
@@ -1,8 +1,5 @@
-import uuid
-
 import dask.dataframe as dd
 import pandas as pd
-from coiled import Cluster
 
 
 def test_quickstart_csv(small_client):
@@ -33,11 +30,3 @@ def test_quickstart_parquet(small_client):
 
     assert isinstance(result, pd.Series)
     assert not result.empty
-
-
-def test_default_cluster_spinup_time(request, auto_benchmark_time):
-
-    with Cluster(
-        name=f"{request.node.originalname}-{uuid.uuid4().hex[:8]}", package_sync=True
-    ):
-        pass


### PR DESCRIPTION
Follow-up from https://github.com/coiled/coiled-runtime/pull/341