### PR TITLE
Block upgrade to pandas 1.5.0

### DIFF
--- a/ci/environment-dashboard.yml
+++ b/ci/environment-dashboard.yml
@@ -13,5 +13,5 @@ dependencies:
   - distributed
   - xarray
   - xgboost
-  - pandas
+  - pandas=1.4  # 1.5 is incompatibile with altair 4.2
   - tabulate


### PR DESCRIPTION
altair 4.2.0 + pandas 1.5.0 produce a ton of DeprecationWarnings