### PR TITLE
Use single job for all test categories

### DIFF
--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -45,7 +45,7 @@ jobs:
   # and AB_environments/config.yaml set repeat > 0
 
   tests:
-    name: A/B Tests - ${{ matrix.category }} ${{ matrix.runtime-version }} ${{ matrix.os }} py${{ matrix.python-version }}
+    name: A/B Tests - ${{ matrix.runtime-version }} ${{ matrix.os }} py${{ matrix.python-version }}
     needs: discover_ab_envs
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
@@ -59,7 +59,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9"]
-        category: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).category }}
+        pytest_args: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).pytest_args }}
         runtime-version: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).runtime }}
         repeat: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).repeat }}
 
@@ -101,17 +101,17 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
-          DB_NAME: ${{ matrix.category }}-${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
+          DB_NAME: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
           BENCHMARK: true
           CLUSTER_DUMP: true
-        run: bash ci/scripts/run_tests.sh tests/${{ matrix.category }}
+        run: bash ci/scripts/run_tests.sh ${{ matrix.pytest_args }}
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.category }}-${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}
-          path: ${{ matrix.category }}-${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
+          name: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}
+          path: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
 
   process-results:
     needs: [discover_ab_envs, tests]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
   tests:
-    name: Tests - ${{ matrix.category }} ${{ matrix.runtime-version }} ${{ matrix.os }} py${{ matrix.python-version }}
+    name: Tests - ${{ matrix.runtime-version }} ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -31,49 +31,49 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9"]
-        category: [runtime, benchmarks, stability]
+        pytest_args: [tests]
         runtime-version: [upstream, latest, "0.0.4", "0.1.0"]
         include:
           # Run stability tests on Python 3.8
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.8"
             runtime-version: upstream
             os: ubuntu-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.8"
             runtime-version: latest
             os: ubuntu-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.8"
             runtime-version: "0.0.4"
             os: ubuntu-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.8"
             runtime-version: "0.1.0"
             os: ubuntu-latest
           # Run stability tests on Python 3.10
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.10"
             runtime-version: upstream
             os: ubuntu-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.10"
             runtime-version: latest
             os: ubuntu-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.10"
             runtime-version: "0.0.4"
             os: ubuntu-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.10"
             runtime-version: "0.1.0"
             os: ubuntu-latest
           # Run stability tests on Python Windows and MacOS (latest py39 only)
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.9"
             runtime-version: latest
             os: windows-latest
-          - category: stability
+          - pytest_args: tests/stability
             python-version: "3.9"
             runtime-version: latest
             os: macos-latest
@@ -107,17 +107,17 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
-          DB_NAME: ${{ matrix.category }}-${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
+          DB_NAME: ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
           BENCHMARK: true
           CLUSTER_DUMP: true
-        run: bash ci/scripts/run_tests.sh tests/${{ matrix.category }}
+        run: bash ci/scripts/run_tests.sh ${{ matrix.pytest_args }}
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.category }}-${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}
-          path: ${{ matrix.category }}-${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
+          name: ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}
+          path: ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
 
   process-results:
     needs: tests

--- a/AB_environments/config.yaml
+++ b/AB_environments/config.yaml
@@ -2,7 +2,7 @@
 # Lower values are faster and cheaper but will result in higher variance.
 # This must remain set to 0 in the main branch, thus completely disabling
 # A/B tests, in order to avoid unnecessary runs.
-repeat: 0
+repeat: 1
 
 # Set to true to automatically create a verbatim copy of AB_baseline and then compare
 # the two in the A/B tests. Set to false to save some money if you are already confident

--- a/AB_environments/config.yaml
+++ b/AB_environments/config.yaml
@@ -2,7 +2,7 @@
 # Lower values are faster and cheaper but will result in higher variance.
 # This must remain set to 0 in the main branch, thus completely disabling
 # A/B tests, in order to avoid unnecessary runs.
-repeat: 1
+repeat: 0
 
 # Set to true to automatically create a verbatim copy of AB_baseline and then compare
 # the two in the A/B tests. Set to false to save some money if you are already confident

--- a/ci/scripts/discover_ab_environments.py
+++ b/ci/scripts/discover_ab_environments.py
@@ -3,17 +3,29 @@ from __future__ import annotations
 import glob
 import json
 import os.path
+from typing import TypedDict
 
 import yaml
 
 
-def build_json() -> dict[str, list[int]]:
+class JSONOutput(TypedDict):
+    repeat: list[int]
+    runtime: list[str]
+    pytest_args: list[str]
+
+
+def build_json() -> JSONOutput:
     with open("AB_environments/config.yaml") as fh:
         cfg = yaml.safe_load(fh)
+
     if not isinstance(cfg.get("repeat"), int) or cfg["repeat"] < 0:
         raise ValueError("AB_environments/config.yaml: missing key {repeat: N}")
-    if not cfg["repeat"]:
-        return {"repeat": [], "runtime": [], "category": []}
+    for category in cfg["categories"]:
+        if not glob.glob(f"tests/{category}/test_*.py"):
+            raise ValueError("fNot a valid test category: {category}")
+
+    if not cfg["repeat"] or not cfg["categories"]:
+        return {"repeat": [], "runtime": [], "pytest_args": []}
 
     runtimes = []
     for conda_fname in sorted(glob.glob("AB_environments/AB_*.conda.yaml")):
@@ -24,7 +36,7 @@ def build_json() -> dict[str, list[int]]:
         runtimes.append(env_name)
 
     if not runtimes:
-        return {"repeat": [], "runtime": [], "category": []}
+        return {"repeat": [], "runtime": [], "pytest_args": []}
 
     if "AB_baseline" not in runtimes:
         # If any A/B environments are defined, AB_baseline is required
@@ -36,7 +48,7 @@ def build_json() -> dict[str, list[int]]:
     return {
         "repeat": list(range(1, cfg["repeat"] + 1)),
         "runtime": runtimes,
-        "category": cfg["categories"],
+        "pytest_args": [" ".join(f"tests/{c}" for c in cfg["categories"])],
     }
 
 

--- a/ci/scripts/run_tests.sh
+++ b/ci/scripts/run_tests.sh
@@ -16,5 +16,4 @@ then
   EXTRA_OPTIONS="$EXTRA_OPTIONS --benchmark"
 fi
 
-python -m pytest -n 10 --dist loadscope $EXTRA_OPTIONS "$@"
-
+python -m pytest -n 8 --dist loadscope $EXTRA_OPTIONS $@


### PR DESCRIPTION
Use pytest-xdist to parallelize [stability, runtime, benchmarks] instead of github actions.

Closes #279