### PR TITLE
Set backend option to send prometheus metrics

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -414,7 +414,7 @@ def small_cluster(request, dask_env_variables):
         n_workers=10,
         worker_vm_types=["t3.large"],  # 2CPU, 8GiB
         scheduler_vm_types=["t3.xlarge"],
-        backend_options={"send_prometheus_metrics": True, **backend_options},
+        backend_options={"send_prometheus_metrics": True, **backend_options},  # hi
         package_sync=True,
         environ=dask_env_variables,
     ) as cluster:

--- a/conftest.py
+++ b/conftest.py
@@ -408,13 +408,15 @@ def small_cluster(request, dask_env_variables):
     backend_options = merge(
         m.kwargs for m in request.node.iter_markers(name="backend_options")
     )
+    backend_options["send_prometheus_metrics"] = True
+
     module = os.path.basename(request.fspath).split(".")[0]
     with Cluster(
         name=f"{module}-{uuid.uuid4().hex[:8]}",
         n_workers=10,
         worker_vm_types=["t3.large"],  # 2CPU, 8GiB
         scheduler_vm_types=["t3.xlarge"],
-        backend_options={"send_prometheus_metrics": True, **backend_options},
+        backend_options=backend_options,
         package_sync=True,
         environ=dask_env_variables,
     ) as cluster:

--- a/conftest.py
+++ b/conftest.py
@@ -414,10 +414,7 @@ def small_cluster(request, dask_env_variables):
         n_workers=10,
         worker_vm_types=["t3.large"],  # 2CPU, 8GiB
         scheduler_vm_types=["t3.xlarge"],
-        backend_options={
-            "send_prometheus_metrics": True,
-            **backend_options
-        },
+        backend_options={"send_prometheus_metrics": True, **backend_options},
         package_sync=True,
         environ=dask_env_variables,
     ) as cluster:

--- a/conftest.py
+++ b/conftest.py
@@ -414,7 +414,10 @@ def small_cluster(request, dask_env_variables):
         n_workers=10,
         worker_vm_types=["t3.large"],  # 2CPU, 8GiB
         scheduler_vm_types=["t3.xlarge"],
-        backend_options=backend_options,
+        backend_options={
+            "send_prometheus_metrics": True,
+            **backend_options
+        },
         package_sync=True,
         environ=dask_env_variables,
     ) as cluster:

--- a/conftest.py
+++ b/conftest.py
@@ -414,7 +414,7 @@ def small_cluster(request, dask_env_variables):
         n_workers=10,
         worker_vm_types=["t3.large"],  # 2CPU, 8GiB
         scheduler_vm_types=["t3.xlarge"],
-        backend_options={"send_prometheus_metrics": True, **backend_options},  # hi
+        backend_options={"send_prometheus_metrics": True, **backend_options},
         package_sync=True,
         environ=dask_env_variables,
     ) as cluster:

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -23,6 +23,7 @@ def parquet_cluster(dask_env_variables):
         scheduler_vm_types=["m5.xlarge"],
         package_sync=True,
         environ=dask_env_variables,
+        backend_options={"send_prometheus_metrics": True},
     ) as cluster:
         yield cluster
 

--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -33,6 +33,7 @@ def test_work_stealing_on_scaling_up(
         wait_for_workers=True,
         package_sync=True,
         environ=dask_env_variables,
+        backend_options={"send_prometheus_metrics": True},
     ) as cluster:
         with Client(cluster) as client:
             # FIXME https://github.com/coiled/platform/issues/103

--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -22,6 +22,7 @@ def test_repeated_merge_spill(upload_cluster_dump, benchmark_all, dask_env_varia
         wait_for_workers=True,
         package_sync=True,
         environ=dask_env_variables,
+        backend_options={"send_prometheus_metrics": True},
     ) as cluster:
         with Client(cluster) as client:
             with upload_cluster_dump(client, cluster), benchmark_all(client):

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -17,6 +17,7 @@ def spill_cluster(dask_env_variables):
         worker_vm_types=["t3.large"],
         scheduler_vm_types=["t3.xlarge"],
         wait_for_workers=True,
+        backend_options={"send_prometheus_metrics": True},
         environ=merge(
             dask_env_variables,
             {


### PR DESCRIPTION
I'd like to collect metrics from at least one CI run.

Maybe we want to do this for every CI run, but we should at least check the cost first.