### PR TITLE
Reduce A/B parallelism

### DIFF
--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -55,8 +55,9 @@ jobs:
       # AWS implements limiters to how many EC2 instances you can spawn in parallel *on
       # the same AWS account*. If such limit is reached, jobs will randomly fail when
       # trying to create the Coiled clusters, and restarting failed jobs won't fix the
-      # problem.
-      max-parallel: 20
+      # problem. Additionally, there are problems with Coiled itself triggered by
+      # limitations that are never actually reached with real paying users.
+      max-parallel: 5
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9"]


### PR DESCRIPTION
Reduce maximum number of clusters created at the same time for each A/B test suite from 140 to 35.

Note that this does not put a cap on the absolute maximum number of parallel runs; if multiple A/B branches are pushed at the same time, there are going to be 35 coiled clusters spun up for each branch.