### PR TITLE
Remove quickstart examples

### DIFF
--- a/tests/benchmarks/test_csv.py
+++ b/tests/benchmarks/test_csv.py
@@ -2,7 +2,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 
-def test_quickstart_csv(small_client):
+def test_csv_basic(small_client):
     ddf = dd.read_csv(
         "s3://coiled-runtime-ci/nyc-tlc/yellow_tripdata_2019_csv/yellow_tripdata_2019-*.csv",
         dtype={
@@ -12,18 +12,6 @@ def test_quickstart_csv(small_client):
             "RatecodeID": "UInt8",
         },
         blocksize="16 MiB",
-    ).persist()
-
-    result = ddf.groupby("passenger_count").tip_amount.mean().compute()
-
-    assert isinstance(result, pd.Series)
-    assert not result.empty
-
-
-def test_quickstart_parquet(small_client):
-    ddf = dd.read_parquet(
-        "s3://coiled-runtime-ci/nyc-tlc/yellow_tripdata_2019_parquet/yellow_tripdata_2019-*.parquet",
-        columns=["passenger_count", "tip_amount"],
     ).persist()
 
     result = ddf.groupby("passenger_count").tip_amount.mean().compute()

--- a/tests/runtime/test_coiled.py
+++ b/tests/runtime/test_coiled.py
@@ -1,0 +1,7 @@
+import coiled
+
+
+def test_reconnect(small_cluster):
+    """How quickly can we reconnect to an existing cluster?"""
+    with coiled.Cluster(name=small_cluster.name):
+        pass


### PR DESCRIPTION
These are no longer used as the quickstart on cloud.coiled.io. Let's keep the csv example so we can continue to monitor `read_csv` performance. We have other `read_parquet` benchmarks that capture the parquet version of the old quickstart, so we can just remove that one. 