### PR TITLE
Use `package_sync` in `test_work_stealing_on_straggling_worker`

### DIFF
--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -87,6 +87,7 @@ def test_work_stealing_on_straggling_worker(
         n_workers=10,
         worker_vm_types=["t3.medium"],
         scheduler_vm_types=["t3.xlarge"],
+        package_sync=True,
         wait_for_workers=True,
         environ=dask_env_variables,
     ) as cluster:


### PR DESCRIPTION
We're currently seeing package mismatches in CI as `package_sync` isn't being used 

cc @hendrikmakait @crusaderky 

cc @shughes-uk in case you have time to add a `package_sync` config value