### PR TITLE
Param array test ddiff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,52 +31,52 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9"]
-        pytest_args: [tests]
+        pytest_args: [tests/benchmarks/test_array.py::test_double_diff]
         runtime-version: [upstream, latest, "0.0.4", "0.1.0"]
-        include:
-          # Run stability tests on Python 3.8
-          - pytest_args: tests/stability
-            python-version: "3.8"
-            runtime-version: upstream
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.8"
-            runtime-version: latest
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.8"
-            runtime-version: "0.0.4"
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.8"
-            runtime-version: "0.1.0"
-            os: ubuntu-latest
-          # Run stability tests on Python 3.10
-          - pytest_args: tests/stability
-            python-version: "3.10"
-            runtime-version: upstream
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.10"
-            runtime-version: latest
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.10"
-            runtime-version: "0.0.4"
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.10"
-            runtime-version: "0.1.0"
-            os: ubuntu-latest
-          # Run stability tests on Python Windows and MacOS (latest py39 only)
-          - pytest_args: tests/stability
-            python-version: "3.9"
-            runtime-version: latest
-            os: windows-latest
-          - pytest_args: tests/stability
-            python-version: "3.9"
-            runtime-version: latest
-            os: macos-latest
+        # include:
+        #   # Run stability tests on Python 3.8
+        #   - pytest_args: tests/stability
+        #     python-version: "3.8"
+        #     runtime-version: upstream
+        #     os: ubuntu-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.8"
+        #     runtime-version: latest
+        #     os: ubuntu-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.8"
+        #     runtime-version: "0.0.4"
+        #     os: ubuntu-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.8"
+        #     runtime-version: "0.1.0"
+        #     os: ubuntu-latest
+        #   # Run stability tests on Python 3.10
+        #   - pytest_args: tests/stability
+        #     python-version: "3.10"
+        #     runtime-version: upstream
+        #     os: ubuntu-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.10"
+        #     runtime-version: latest
+        #     os: ubuntu-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.10"
+        #     runtime-version: "0.0.4"
+        #     os: ubuntu-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.10"
+        #     runtime-version: "0.1.0"
+        #     os: ubuntu-latest
+        #   # Run stability tests on Python Windows and MacOS (latest py39 only)
+        #   - pytest_args: tests/stability
+        #     python-version: "3.9"
+        #     runtime-version: latest
+        #     os: windows-latest
+        #   - pytest_args: tests/stability
+        #     python-version: "3.9"
+        #     runtime-version: latest
+        #     os: macos-latest
 
     steps:
       - name: Checkout

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -135,10 +135,14 @@ def test_vorticity(small_client):
     wait(arr_to_devnull(result), small_client, 10 * 60)
 
 
-def test_double_diff(small_client):
+@pytest.mark.parametrize("ds_size_fraction_of_cluster", [(1),(2)])
+def test_double_diff(ds_size_fraction_of_cluster, small_client):
     # Variant of https://github.com/dask/distributed/issues/6597
-    memory = cluster_memory(small_client)  # 76.66 GiB
 
+    # We speculate this test shows a lot of variability due to high memory pressure
+    # Here we reduce memory pressure to assess Dask's behavior.  This will catch issues
+    # like https://github.com/dask/dask/issues/9488
+    memory = cluster_memory(small_client) / ds_size_fraction_of_cluster  # 76.66 GiB
     # TODO switch back to chunksizes in the `chunks=` argument everywhere
     #  when https://github.com/dask/dask/issues/9488 is fixed
     cs = int((parse_bytes("20 MiB") / 8) ** (1 / 2))

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -140,14 +140,12 @@ def test_double_diff(ds_size_fraction_of_cluster, small_client):
     # Variant of https://github.com/dask/distributed/issues/6597
 
     # We speculate this test shows a lot of variability due to high memory pressure
-    # Here we reduce memory pressure to assess Dask's behavior.  This will catch issues
-    # like https://github.com/dask/dask/issues/9488
+    # Here we can assess Dask's behavior under both conditions.
+    # This will catch issues like https://github.com/dask/dask/issues/9488
     memory = cluster_memory(small_client) / ds_size_fraction_of_cluster  # 76.66 GiB
-    # TODO switch back to chunksizes in the `chunks=` argument everywhere
-    #  when https://github.com/dask/dask/issues/9488 is fixed
-    cs = int((parse_bytes("20 MiB") / 8) ** (1 / 2))
-    a = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=(cs, cs))
-    b = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=(cs, cs))
+
+    a = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=("20MiB", "20MiB"))
+    b = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=("20MiB", "20MiB"))
     print_size_info(memory, memory, a, b)
 
     diff = a[1:, 1:] - b[:-1, :-1]

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -135,7 +135,7 @@ def test_vorticity(small_client):
     wait(arr_to_devnull(result), small_client, 10 * 60)
 
 
-@pytest.mark.parametrize("ds_size_fraction_of_cluster", [(1),(2)])
+@pytest.mark.parametrize("ds_size_fraction_of_cluster", [(1), (2)])
 def test_double_diff(ds_size_fraction_of_cluster, small_client):
     # Variant of https://github.com/dask/distributed/issues/6597
 
@@ -144,8 +144,12 @@ def test_double_diff(ds_size_fraction_of_cluster, small_client):
     # This will catch issues like https://github.com/dask/dask/issues/9488
     memory = cluster_memory(small_client) / ds_size_fraction_of_cluster  # 76.66 GiB
 
-    a = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=("20MiB", "20MiB"))
-    b = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=("20MiB", "20MiB"))
+    a = da.random.random(
+        scaled_array_shape(memory, ("x", "x")), chunks=("20MiB", "20MiB")
+    )
+    b = da.random.random(
+        scaled_array_shape(memory, ("x", "x")), chunks=("20MiB", "20MiB")
+    )
     print_size_info(memory, memory, a, b)
 
     diff = a[1:, 1:] - b[:-1, :-1]


### PR DESCRIPTION
This PR parameterizes `benchmarks/test_array.py::test_double_diff` to allow evaluating this operations behavior under both high and intermediate memory pressure.

In conversations with @ntabris, we suspect the high variance associated with this test is largely due to dask's current handling of spill to disk behavior.