### PR TITLE
Add Snowflake benchmarks (rough) [DNM]

### DIFF
--- a/ci/scripts/install_coiled_runtime.sh
+++ b/ci/scripts/install_coiled_runtime.sh
@@ -10,7 +10,7 @@ then
   cat $1
   mamba env update --file $1
 else
-  mamba install -c conda-forge coiled-runtime=$COILED_RUNTIME_VERSION
+  mamba install -c conda-forge coiled-runtime=$COILED_RUNTIME_VERSION dask-snowflake
 fi
 
 # For debugging

--- a/tests/benchmarks/test_snowflake.py
+++ b/tests/benchmarks/test_snowflake.py
@@ -1,0 +1,58 @@
+import os
+import uuid
+
+import dask
+import dask.dataframe as dd
+import pytest
+from dask_snowflake import read_snowflake, to_snowflake
+from distributed import Client
+from snowflake.sqlalchemy import URL
+from sqlalchemy import create_engine
+
+
+@pytest.fixture
+def client():
+    with Client(n_workers=2, threads_per_worker=10) as client:
+        yield client
+
+
+@pytest.fixture
+def table(connection_kwargs):
+    name = f"test_table_{uuid.uuid4().hex}".upper()
+
+    yield name
+
+    engine = create_engine(URL(**connection_kwargs))
+    engine.execute(f"DROP TABLE IF EXISTS {name}")
+
+
+@pytest.fixture(scope="module")
+def connection_kwargs():
+    return dict(
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.environ["SNOWFLAKE_PASSWORD"],
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        database="testdb",
+        schema="public",
+        warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
+        role=os.environ["SNOWFLAKE_ROLE"],
+    )
+
+
+ddf = dask.datasets.timeseries(
+    start="2000-01-01", end="2000-12-31", freq="1T", partition_freq="1W"
+)
+
+
+def test_write_read_roundtrip(table, connection_kwargs, small_client):
+    to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
+
+    query = f"SELECT * FROM {table}"
+    df_out = (
+        read_snowflake(query, connection_kwargs=connection_kwargs)
+        .rename(columns=str.upper)  # snowflake's column casing is weird
+        .sort_values(by="A")  # sort needed to re-sync the partitions
+        .reset_index(drop=True)
+    )
+
+    dd.utils.assert_eq(ddf, df_out, check_dtype=False)


### PR DESCRIPTION
Couple of things to address with this:

1. Need the snowflake creds added as secrets to the repo
2. I just tacked `dask-snowflake` into the conda install command. Didn't add it to the requirements. I don't think it should be a requirement for the runtime, but it wouldn't be difficult to convince me that it could be
3. Based on user reports, I think it'd be nice to break to the read/write into separate benchmarks by getting more granular with the fixtures and context managers.