### PR TITLE
Use a single worker for cluster spinup time

### DIFF
--- a/tests/runtime/test_cluster_creation.py
+++ b/tests/runtime/test_cluster_creation.py
@@ -11,6 +11,7 @@ def test_default_cluster_spinup_time(auto_benchmark_time, test_run_benchmark):
     """
     with Cluster(
         name=f"test_default_cluster_spinup_time-{uuid.uuid4().hex[:8]}",
+        n_workers=1,
         package_sync=True,
     ) as cluster:
         test_run_benchmark.cluster_name = cluster.name


### PR DESCRIPTION
Currently we're using the default number of workers (i.e. 4) for measuring how fast a cluster spins up. This PR proposes we only spin up a single worker. This will, I think, provide the same rough time estimate we're after, while using fewer AWS resources. 

cc @ntabris 