### PR TITLE
Update `numba` for M1 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - dask-labextension ==5.2.0
     - lz4 ==4.0.0
     - ipywidgets ==7.7.0
-    - numba ==0.55.1
+    - numba ==0.56.3
     - scikit-learn ==1.1.1
     - ipycytoscape ==1.3.3
     - click ==8.1.3


### PR DESCRIPTION
This PR updates `numba` to the latest release `0.56.3`. This fixes installation problems when using `pip install .` to install the metapackage dependencies on an Apple M1 as prescribed in https://github.com/coiled/coiled-runtime/blob/595c449f9a8c55ffe23d64c639314c46a4db1540/README.md#create-your-software-environment.

Native installation support for `numba` using `pip` on an Apple M1 has been added in `0.55.2` (https://github.com/numba/numba/releases/tag/0.55.2), so in case something breaks due to the minor version upgrade, we could use that one instead.

