### PR TITLE
Restart cluster during teardown to avoid failures spilling over

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -457,10 +457,10 @@ def small_client(
     with Client(small_cluster) as client:
         small_cluster.scale(10)
         client.wait_for_workers(10)
-        client.restart()
 
         with upload_cluster_dump(client), benchmark_all(client):
             yield client
+        client.restart()
 
 
 S3_REGION = "us-east-2"

--- a/conftest.py
+++ b/conftest.py
@@ -455,6 +455,7 @@ def small_client(
     benchmark_all,
 ):
     with Client(small_cluster) as client:
+        client.restart()
         small_cluster.scale(10)
         client.wait_for_workers(10)
 


### PR DESCRIPTION
This PR adds a cluster restart to teardown to avoid that failures/side-effects spill over into setup of subsequent tests.