### PR TITLE
Log `small_client` fixture phases on the scheduler

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -467,7 +467,7 @@ def small_cluster(request, dask_env_variables, gitlab_cluster_tags):
 def log_on_scheduler(
     client: Client, msg: str, *args, level: int = logging.INFO
 ) -> None:
-    client.run_on_scheduler(scheduler_logger.log, level=level, msg=msg, *args)
+    client.run_on_scheduler(scheduler_logger.log, level, msg, *args)
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -436,6 +436,7 @@ def test_name_uuid(request):
     "Test name, suffixed with a UUID. Useful for resources like cluster names, S3 paths, etc."
     return f"{request.node.originalname}-{uuid.uuid4().hex}"
 
+
 @pytest.fixture(scope="session")
 def dask_env_variables():
     return {k: v for k, v in os.environ.items() if k.startswith("DASK_")}
@@ -462,8 +463,12 @@ def small_cluster(request, dask_env_variables, gitlab_cluster_tags):
     ) as cluster:
         yield cluster
 
-def log_on_scheduler(client: Client, msg: str, *args, level: int=logging.INFO) -> None:
+
+def log_on_scheduler(
+    client: Client, msg: str, *args, level: int = logging.INFO
+) -> None:
     client.run_on_scheduler(scheduler_logger.log, level=level, msg=msg, *args)
+
 
 @pytest.fixture
 def small_client(

--- a/conftest.py
+++ b/conftest.py
@@ -433,7 +433,9 @@ def gitlab_cluster_tags():
 
 @pytest.fixture
 def test_name_uuid(request):
-    "Test name, suffixed with a UUID. Useful for resources like cluster names, S3 paths, etc."
+    """Test name, suffixed with a UUID.
+    Useful for resources like cluster names, S3 paths, etc.
+    """
     return f"{request.node.originalname}-{uuid.uuid4().hex}"
 
 
@@ -472,21 +474,23 @@ def log_on_scheduler(
 
 @pytest.fixture
 def small_client(
-    test_name_uuid,
+    request,
+    testrun_uid,
     small_cluster,
     upload_cluster_dump,
     benchmark_all,
 ):
+    test_label = f"{request.node.name}, session_id={testrun_uid}"
     with Client(small_cluster) as client:
-        log_on_scheduler(client, "Starting client setup of '%s'", test_name_uuid)
+        log_on_scheduler(client, "Starting client setup of %s", test_label)
         client.restart()
         small_cluster.scale(10)
         client.wait_for_workers(10)
 
         with upload_cluster_dump(client), benchmark_all(client):
-            log_on_scheduler(client, "Finished client setup of '%s'", test_name_uuid)
+            log_on_scheduler(client, "Finished client setup of %s", test_label)
             yield client
-            log_on_scheduler(client, "Starting client teardown of '%s'", test_name_uuid)
+            log_on_scheduler(client, "Starting client teardown of %s", test_label)
         client.restart()
 
 


### PR DESCRIPTION
This PR logs when we start/finish setup/teardown of the `small_client` fixture on the scheduler. This helps to correlate cluster logs with issues. We have seen some CI failures in the cluster (e.g. #441) where being able to pinpoint when these phases happen would have facilitated debugging.

Merge conflicts with:
* #472