### PR TITLE
Measure cluster connect time

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The most relevant ones are summarized here:
 
 **`benchmark_task_durations`**: Record time spent computing, transferring data, spilling to disk, and deserializing data.
 
-**`auto_benchmark_time`**: Include this fixture to measure the wall clock time of the whole test automatically.
+**`get_cluster_info`**: Record cluster id, name, etc.
 
 **`benchmark_all`**: Record all available metrics.
 

--- a/conftest.py
+++ b/conftest.py
@@ -218,10 +218,6 @@ def benchmark_time(test_run_benchmark):
         def test_something(benchmark_time):
             with benchmark_time:
                 do_something()
-
-    See Also
-    --------
-    auto_benchmark_time
     """
 
     @contextlib.contextmanager
@@ -237,31 +233,6 @@ def benchmark_time(test_run_benchmark):
             test_run_benchmark.end = datetime.datetime.utcfromtimestamp(end)
 
     return _benchmark_time()
-
-
-@pytest.fixture(scope="function")
-def auto_benchmark_time(benchmark_time):
-    """Benchmark the wall clock time of an individual test.
-
-    This fixture automatically records the wall clock time it takes to
-    execute an individual test if run as part of a benchmark. Depending on the test's structure, this may
-    include setup or teardown code that should not be measured. For more
-    control, use the ``benchmark_time`` context manager fixture.
-
-
-    Example
-    -------
-    .. code-block:: python
-
-        def test_something(auto_benchmark_time):
-            do_something()
-
-    See Also
-    --------
-    benchmark_time
-    """
-    with benchmark_time:
-        yield
 
 
 @pytest.fixture(scope="function")
@@ -358,14 +329,14 @@ def get_cluster_info(test_run_benchmark):
     """
 
     @contextlib.contextmanager
-    def _get_cluster_info(client):
+    def _get_cluster_info(cluster):
         if not test_run_benchmark:
             yield
         else:
             yield
-            test_run_benchmark.cluster_name = client.cluster.name
-            test_run_benchmark.cluster_id = client.cluster.cluster_id
-            test_run_benchmark.cluster_details_url = client.cluster.details_url
+            test_run_benchmark.cluster_name = cluster.name
+            test_run_benchmark.cluster_id = cluster.cluster_id
+            test_run_benchmark.cluster_details_url = cluster.details_url
 
     yield _get_cluster_info
 
@@ -406,7 +377,7 @@ def benchmark_all(
     def _benchmark_all(client):
         with benchmark_memory(client), benchmark_task_durations(
             client
-        ), get_cluster_info(client), benchmark_time:
+        ), get_cluster_info(client.cluster), benchmark_time:
             yield
 
     yield _benchmark_all

--- a/tests/runtime/test_cluster_creation.py
+++ b/tests/runtime/test_cluster_creation.py
@@ -4,20 +4,18 @@ from coiled import Cluster
 
 
 def test_default_cluster_spinup_time(
-    auto_benchmark_time, test_run_benchmark, gitlab_cluster_tags
+    benchmark_time, gitlab_cluster_tags, get_cluster_info
 ):
     """Note: this test must be kept in a separate module from the tests that use the
     small_cluster fixture (which has the scope=module) or its child small_client.
     This prevents having the small_cluster sitting idle for 5+ minutes while this test
     is running.
     """
-    with Cluster(
-        name=f"test_default_cluster_spinup_time-{uuid.uuid4().hex[:8]}",
-        package_sync=True,
-        tags=gitlab_cluster_tags,
-    ) as cluster:
-        test_run_benchmark.cluster_name = cluster.name
-        test_run_benchmark.cluster_id = cluster.cluster_id
-        test_run_benchmark.cluster_details_url = cluster.details_url
-
-        pass
+    with benchmark_time:
+        with Cluster(
+            name=f"test_default_cluster_spinup_time-{uuid.uuid4().hex[:8]}",
+            package_sync=True,
+            tags=gitlab_cluster_tags,
+        ) as cluster:
+            with get_cluster_info(cluster):
+                pass

--- a/tests/runtime/test_coiled.py
+++ b/tests/runtime/test_coiled.py
@@ -1,7 +1,16 @@
-import coiled
+from coiled import Cluster
+from distributed import Client
 
 
-def test_reconnect(small_cluster):
+def test_cluster_reconnect(small_cluster, get_cluster_info, benchmark_time):
     """How quickly can we reconnect to an existing cluster?"""
-    with coiled.Cluster(name=small_cluster.name):
-        pass
+    with get_cluster_info(small_cluster), benchmark_time:
+        with Cluster(name=small_cluster.name, shutdown_on_close=False):
+            pass
+
+
+def test_client_connect(small_cluster, get_cluster_info, benchmark_time):
+    """How quickly can we connect a client to an existing cluster?"""
+    with get_cluster_info(small_cluster), benchmark_time:
+        with Client(small_cluster):
+            pass

--- a/tests/runtime/test_coiled.py
+++ b/tests/runtime/test_coiled.py
@@ -1,18 +1,8 @@
 from coiled import Cluster
-from distributed import Client
 
 
 def test_cluster_reconnect(small_cluster, get_cluster_info, benchmark_time):
     """How quickly can we reconnect to an existing cluster?"""
     with get_cluster_info(small_cluster), benchmark_time:
-        for _ in range(10):
-            with Cluster(name=small_cluster.name, shutdown_on_close=False):
-                pass
-
-
-def test_client_connect(small_cluster, get_cluster_info, benchmark_time):
-    """How quickly can we connect a client to an existing cluster?"""
-    with get_cluster_info(small_cluster), benchmark_time:
-        for _ in range(10):
-            with Client(small_cluster):
-                pass
+        with Cluster(name=small_cluster.name, shutdown_on_close=False):
+            pass

--- a/tests/runtime/test_coiled.py
+++ b/tests/runtime/test_coiled.py
@@ -5,12 +5,14 @@ from distributed import Client
 def test_cluster_reconnect(small_cluster, get_cluster_info, benchmark_time):
     """How quickly can we reconnect to an existing cluster?"""
     with get_cluster_info(small_cluster), benchmark_time:
-        with Cluster(name=small_cluster.name, shutdown_on_close=False):
-            pass
+        for _ in range(10):
+            with Cluster(name=small_cluster.name, shutdown_on_close=False):
+                pass
 
 
 def test_client_connect(small_cluster, get_cluster_info, benchmark_time):
     """How quickly can we connect a client to an existing cluster?"""
     with get_cluster_info(small_cluster), benchmark_time:
-        with Client(small_cluster):
-            pass
+        for _ in range(10):
+            with Client(small_cluster):
+                pass


### PR DESCRIPTION
- Measure cluster reconnect time. The test already existed but it was not recording anything.
- Remove auto_benchmark_time fixture, as it was sensitive to ordering issues with other fixtures