### PR TITLE
Fix `test_access_slices`

### DIFF
--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -248,13 +248,12 @@ def test_filter_then_average(threshold, zarr_dataset, small_client):
     zarr_dataset[zarr_dataset > threshold].mean().compute()
 
 
-@pytest.mark.skip(reason="this test crashed ci workers -see issue #477")
 @pytest.mark.parametrize("N", [700, 75, 1])
 def test_access_slices(N, zarr_dataset, small_client):
     """
     Accessing just a few chunks of a zarr array should be quick
     """
-    zarr_dataset[:N, :N, :N].compute()
+    zarr_dataset[:N, :N, :N].persist()
 
 
 def test_sum_residuals(zarr_dataset, small_client):


### PR DESCRIPTION
This PR persists the data accessed in `test_access_slices` on the cluster instead of moving it to the client (and dropping it right after). This reduces the memory footprint of the client since the accessed slice takes up ~2.5 GB for `N==700`. This should solve the problem with `pytest-xdist` workers dying.

**Explanation**

This solution is based on theory and trying the change on CI, not any useful information gathered from CI errors. All I can tell is that the `pytest-xdist` workers are dying _for some reason_ with
```
[gw0] linux -- Python 3.9.13 /usr/share/miniconda3/envs/test/bin/python
worker 'gw0' crashed while running 'tests/benchmarks/test_array.py::test_access_slices[700]'
```

Running `test_access_slices` locally with `.compute()` led to the client process starting to eat up a good chunk of memory and was horribly slow. Switching `.compute()` with `.persist()` made the computation return almost instantly and left memory usage flat.

Our Github-hosted CI runners should only have [7 GB of RAM for Linux VMs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), so reading a large dataset in a `pytest` runner is probably not a good idea (and benchmarks network bandwidth more than anything else). I could see this increase the r

 * Fixes #477