### PR TITLE
Build docker images for ARM (+x86)

### DIFF
--- a/.github/workflows/software-environments-nightly.yml
+++ b/.github/workflows/software-environments-nightly.yml
@@ -67,6 +67,7 @@ jobs:
           push: true
           tags: coiled/coiled-runtime:nightly-${{ env.RUNTIME_NIGHTLY_VERSION }}-py${{ matrix.python-version }}
           build-args: ENV_FILENAME=${{ env.ENV_FILENAME }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Create Runtime ${{ env.RUNTIME_NIGHTLY_VERSION}}, Python ${{ matrix.python-version }}, Server ${{ matrix.server }} software environment
         env:


### PR DESCRIPTION
Unless this breaks something (or drastically increases build time?) I'd like us to build both x86 and arm docker images. This would make it much easier to use `coiled-runtime` on Coiled with ARM instances.