### PR TITLE
Use spot + fallback + multizone for all clusters

### DIFF
--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -23,7 +23,11 @@ def parquet_cluster(dask_env_variables, gitlab_cluster_tags):
         scheduler_vm_types=["m5.xlarge"],
         package_sync=True,
         environ=dask_env_variables,
-        backend_options={"send_prometheus_metrics": True},
+        backend_options={
+            "spot": True,
+            "spot_on_demand_fallback": True,
+            "multizone": True,
+        },
         tags=gitlab_cluster_tags,
     ) as cluster:
         yield cluster

--- a/tests/stability/conftest.py
+++ b/tests/stability/conftest.py
@@ -3,7 +3,9 @@ import pytest
 
 def pytest_collection_modifyitems(config, items):
     # Ensure stability tests use spot instances by default
-    marker = pytest.mark.backend_options(spot=True, spot_on_demand_fallback=True)
+    marker = pytest.mark.backend_options(
+        spot=True, spot_on_demand_fallback=True, multizone=True
+    )
     for item in items:
         # Add a module-level `spot=True` backend option marker if one doesn't already exist
         module = item.parent

--- a/tests/stability/test_spill.py
+++ b/tests/stability/test_spill.py
@@ -17,7 +17,11 @@ def spill_cluster(dask_env_variables, gitlab_cluster_tags):
         worker_vm_types=["m6i.large"],
         scheduler_vm_types=["m6i.xlarge"],
         wait_for_workers=True,
-        backend_options={"send_prometheus_metrics": True},
+        backend_options={
+            "spot": True,
+            "spot_on_demand_fallback": True,
+            "multizone": True,
+        },
         environ=merge(
             dask_env_variables,
             {


### PR DESCRIPTION
Fixes #507

(I also removed backend_option to send prometheus metrics since I now have that set at account-level for `dask-engineering` account.)