### PR TITLE
Build (stable) docker image for ARM (+x86)

### DIFF
--- a/.github/workflows/software-environments-stable.yml
+++ b/.github/workflows/software-environments-stable.yml
@@ -44,6 +44,12 @@ jobs:
           echo $COILED_SOFTWARE_ENV_NAME
           echo COILED_SOFTWARE_ENV_NAME=$COILED_SOFTWARE_ENV_NAME >> $GITHUB_ENV
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -56,6 +62,7 @@ jobs:
           push: true
           tags: coiled/coiled-runtime:${{ matrix.runtime-version }}-py${{ matrix.python-version }}
           build-args: ENV_FILENAME=${{ env.COILED_SOFTWARE_ENV_NAME }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Create Runtime ${{ matrix.runtime-version }} Python ${{ matrix.python-version }} ${{ matrix.server }} software environment
         env:


### PR DESCRIPTION
This is working on the nightlies... x86 and arm images are both available at https://hub.docker.com/r/coiled/coiled-runtime/tags?page=1&name=nightly-0.2.0a2211110032-py3

And they work on Coiled with Graviton instances:

```python
import coiled

coiled.create_software_environment(
  name='nightly-py310',
  container='coiled/coiled-runtime:nightly-0.2.0a2211110032-py3.10'
)

cluster = coiled.Cluster(
  software='nightly-py310',
  scheduler_vm_types=['t4g.large'],
  worker_vm_types=['t4g.large']
)
```

So let's build the stable released for ARM.