### PR TITLE
Ensure concurrent restarts are not interfering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         language_version: python3
         exclude: ^alembic/versions/
   -   repo: https://github.com/pycqa/flake8
-      rev: 4.0.1
+      rev: 5.0.4
       hooks:
       - id: flake8
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         language_version: python3
         exclude: ^alembic/versions/
-  -   repo: https://gitlab.com/pycqa/flake8
+  -   repo: https://github.com/pycqa/flake8
       rev: 4.0.1
       hooks:
       - id: flake8

--- a/conftest.py
+++ b/conftest.py
@@ -508,6 +508,12 @@ def small_client(
             log_on_scheduler(client, "Starting client teardown of %s", test_label)
 
         client.restart()
+        # Run connects to all workers once and to ensure they're up before we do
+        # something else. With another call of restart when entering this
+        # fixture again, this can trigger a race condition that kills workers
+        # See https://github.com/dask/distributed/issues/7312 Can be removed
+        # after this issue is fixed.
+        client.run(lambda: None)
 
 
 S3_REGION = "us-east-2"


### PR DESCRIPTION
Explanation why this bypasses the race condition in the comment. See also https://github.com/dask/distributed/issues/7312

Closes https://github.com/coiled/coiled-runtime/issues/468