### PR TITLE
Revert "OLS Workload" fix ci debugging code. 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,52 +31,52 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9"]
-        pytest_args: [tests/stability/test_array.py]
+        pytest_args: [tests]
         runtime-version: [upstream, latest, "0.0.4", "0.1.0"]
-        # include:
-        #   # Run stability tests on Python 3.8
-        #   - pytest_args: tests/stability
-        #     python-version: "3.8"
-        #     runtime-version: upstream
-        #     os: ubuntu-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.8"
-        #     runtime-version: latest
-        #     os: ubuntu-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.8"
-        #     runtime-version: "0.0.4"
-        #     os: ubuntu-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.8"
-        #     runtime-version: "0.1.0"
-        #     os: ubuntu-latest
-        #   # Run stability tests on Python 3.10
-        #   - pytest_args: tests/stability
-        #     python-version: "3.10"
-        #     runtime-version: upstream
-        #     os: ubuntu-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.10"
-        #     runtime-version: latest
-        #     os: ubuntu-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.10"
-        #     runtime-version: "0.0.4"
-        #     os: ubuntu-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.10"
-        #     runtime-version: "0.1.0"
-        #     os: ubuntu-latest
-        #   # Run stability tests on Python Windows and MacOS (latest py39 only)
-        #   - pytest_args: tests/stability
-        #     python-version: "3.9"
-        #     runtime-version: latest
-        #     os: windows-latest
-        #   - pytest_args: tests/stability
-        #     python-version: "3.9"
-        #     runtime-version: latest
-        #     os: macos-latest
+        include:
+          # Run stability tests on Python 3.8
+          - pytest_args: tests/stability
+            python-version: "3.8"
+            runtime-version: upstream
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.8"
+            runtime-version: latest
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.8"
+            runtime-version: "0.0.4"
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.8"
+            runtime-version: "0.1.0"
+            os: ubuntu-latest
+          # Run stability tests on Python 3.10
+          - pytest_args: tests/stability
+            python-version: "3.10"
+            runtime-version: upstream
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.10"
+            runtime-version: latest
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.10"
+            runtime-version: "0.0.4"
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.10"
+            runtime-version: "0.1.0"
+            os: ubuntu-latest
+          # Run stability tests on Python Windows and MacOS (latest py39 only)
+          - pytest_args: tests/stability
+            python-version: "3.9"
+            runtime-version: latest
+            os: windows-latest
+          - pytest_args: tests/stability
+            python-version: "3.9"
+            runtime-version: latest
+            os: macos-latest
 
     steps:
       - name: Checkout

--- a/tests/stability/test_array.py
+++ b/tests/stability/test_array.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.array as da
 import pytest
 
@@ -17,6 +19,9 @@ def test_rechunk_out_of_memory(small_client):
 
 
 @pytest.mark.stability
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="scaled_array_shape fails on windows"
+)
 def test_ols(small_client):
     chunksize = int(1e6)
     memory = cluster_memory(small_client)


### PR DESCRIPTION
Reverts only changes in `test.yml` introduced in coiled/coiled-runtime#443