### PR TITLE
Scale tests with cluster size

### DIFF
--- a/tests/benchmarks/h2o/test_h2o_benchmarks.py
+++ b/tests/benchmarks/h2o/test_h2o_benchmarks.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pytest
 from packaging.version import Version
 
+from ...utils_test import run_up_to_nthreads
+
 
 @pytest.fixture(
     scope="module",
@@ -52,11 +54,13 @@ def ddf(request):
         )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q1(ddf, small_client):
     ddf = ddf[["id1", "v1"]]
     ddf.groupby("id1", dropna=False, observed=True).agg({"v1": "sum"}).compute()
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q2(ddf, small_client):
     ddf = ddf[["id1", "id2", "v1"]]
     (
@@ -66,6 +70,7 @@ def test_q2(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q3(ddf, small_client):
     ddf = ddf[["id3", "v1", "v3"]]
     (
@@ -75,6 +80,7 @@ def test_q3(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q4(ddf, small_client):
     ddf = ddf[["id4", "v1", "v2", "v3"]]
     (
@@ -84,6 +90,7 @@ def test_q4(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q5(ddf, small_client):
     ddf = ddf[["id6", "v1", "v2", "v3"]]
     (
@@ -93,6 +100,7 @@ def test_q5(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 @pytest.mark.skipif(
     Version(dask.__version__) < Version("2022.10.0"),
     reason="No support for median in dask < 2022.10.0",
@@ -106,6 +114,7 @@ def test_q6(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q7(ddf, small_client):
     ddf = ddf[["id3", "v1", "v2"]]
     (
@@ -116,6 +125,7 @@ def test_q7(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q8(ddf, small_client):
     ddf = ddf[["id6", "v1", "v2", "v3"]]
     (
@@ -129,6 +139,7 @@ def test_q8(ddf, small_client):
     )
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed size data")
 def test_q9(ddf, small_client):
     ddf = ddf[["id2", "id4", "v1", "v2"]]
     (

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -10,7 +10,14 @@ import xarray as xr
 from dask.utils import format_bytes, parse_bytes
 from packaging.version import Version
 
-from ..utils_test import arr_to_devnull, cluster_memory, scaled_array_shape, wait
+from ..utils_test import (
+    arr_to_devnull,
+    cluster_memory,
+    run_up_to_nthreads,
+    scaled_array_shape,
+    scaled_array_shape_quadratic,
+    wait,
+)
 
 
 @pytest.fixture(scope="module")
@@ -24,12 +31,13 @@ def zarr_dataset():
 
 def print_size_info(memory: int, target_nbytes: int, *arrs: da.Array) -> None:
     print(
-        f"Cluster memory: {format_bytes(memory)}, target data size: {format_bytes(target_nbytes)}"
+        f"Cluster memory: {format_bytes(memory)}, "
+        f"target data size: {format_bytes(target_nbytes)}"
     )
     for i, arr in enumerate(arrs, 1):
         print(
-            f"Input {i}: {format_bytes(arr.nbytes)} - "
-            f"{arr.npartitions} {format_bytes(arr.blocks[(0,) * arr.ndim].nbytes)} chunks"
+            f"Input {i}: {format_bytes(arr.nbytes)} - {arr.npartitions} "
+            f"{format_bytes(arr.blocks[(0,) * arr.ndim].nbytes)} chunks"
         )
 
 
@@ -102,7 +110,7 @@ def test_basic_sum(small_client, speed, chunk_shape):
     if chunk_shape == "thin":
         chunks = (-1, 1)  # 100 MiB single-column chunks
     else:
-        chunks = (3350, -1)  # 100.32 MiB square-ish chunks
+        chunks = (3350, 3925)  # 100.32 MiB square-ish chunks
 
     memory = cluster_memory(small_client)  # 76.66 GiB
     target_nbytes = memory * 5
@@ -203,12 +211,12 @@ def test_vorticity(small_client):
 def test_double_diff(small_client):
     # Variant of https://github.com/dask/distributed/issues/6597
     memory = cluster_memory(small_client)  # 76.66 GiB
+    # FIXME https://github.com/coiled/coiled-runtime/issues/564
+    #       this algorithm is supposed to scale linearly!
+    shape = scaled_array_shape_quadratic(memory, "76.66 GiB", ("x", "x"))
 
-    # TODO switch back to chunksizes in the `chunks=` argument everywhere
-    #  when https://github.com/dask/dask/issues/9488 is fixed
-    cs = int((parse_bytes("20 MiB") / 8) ** (1 / 2))
-    a = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=(cs, cs))
-    b = da.random.random(scaled_array_shape(memory, ("x", "x")), chunks=(cs, cs))
+    a = da.random.random(shape, chunks="20MiB")
+    b = da.random.random(shape, chunks="20MiB")
     print_size_info(memory, memory, a, b)
 
     diff = a[1:, 1:] - b[:-1, :-1]
@@ -216,7 +224,12 @@ def test_double_diff(small_client):
 
 
 def test_dot_product(small_client):
-    a = da.random.random((24 * 1024, 24 * 1024), chunks="128 MiB")  # 4.5 GiB
+    memory = cluster_memory(small_client)  # 76.66 GiB
+    shape = scaled_array_shape_quadratic(memory // 17, "4.5 GiB", ("x", "x"))
+    a = da.random.random(shape, chunks="128 MiB")
+    print_size_info(memory, memory // 17, a)
+    # Input 1: 4.51 GiB - 49 128.00 MiB chunks
+
     b = (a @ a.T).sum().round(3)
     wait(b, small_client, 10 * 60)
 
@@ -234,12 +247,12 @@ def test_map_overlap_sample(small_client):
     At the time of writing, data creation took 300ms and the
     map_overlap/getitem, took 2-3s
     """
-    x = da.random.random((10000, 10000), chunks=(50, 50))
-
+    x = da.random.random((10000, 10000), chunks=(50, 50))  # 40_000 19.5 kiB chunks
     y = x.map_overlap(lambda x: x, depth=1)
     y[5000:5010, 5000:5010].compute()
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")
 @pytest.mark.parametrize("threshold", [50, 100, 200, 255])
 def test_filter_then_average(threshold, zarr_dataset, small_client):
     """
@@ -248,6 +261,7 @@ def test_filter_then_average(threshold, zarr_dataset, small_client):
     zarr_dataset[zarr_dataset > threshold].mean().compute()
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 @pytest.mark.parametrize("N", [700, 75, 1])
 def test_access_slices(N, zarr_dataset, small_client):
     """
@@ -256,6 +270,7 @@ def test_access_slices(N, zarr_dataset, small_client):
     zarr_dataset[:N, :N, :N].persist()
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 def test_sum_residuals(zarr_dataset, small_client):
     """
     Simnple test to that computes as reduction, the array op, the reduction again

--- a/tests/benchmarks/test_csv.py
+++ b/tests/benchmarks/test_csv.py
@@ -1,7 +1,10 @@
 import dask.dataframe as dd
 import pandas as pd
 
+from ..utils_test import run_up_to_nthreads
 
+
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 def test_csv_basic(small_client):
     ddf = dd.read_csv(
         "s3://coiled-runtime-ci/nyc-tlc/yellow_tripdata_2019_csv/yellow_tripdata_2019-*.csv",

--- a/tests/benchmarks/test_futures.py
+++ b/tests/benchmarks/test_futures.py
@@ -3,7 +3,10 @@ import pytest
 from dask.distributed import as_completed, wait
 from distributed.utils_test import inc, slowdec, slowinc
 
+from ..utils_test import run_up_to_nthreads
 
+
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 def test_single_future(small_client):
     """How quickly can we run a simple computation?
     Repeat the test a few times to get a more sensible
@@ -13,12 +16,14 @@ def test_single_future(small_client):
         small_client.submit(inc, i).result()
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 def test_large_map(small_client):
     """What's the overhead of map these days?"""
     futures = small_client.map(inc, range(100_000))
     wait(futures)
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 @pytest.mark.skip(
     reason="Skip until https://github.com/coiled/coiled-runtime/issues/521 is fixed"
 )
@@ -33,6 +38,7 @@ def test_large_map_first_work(small_client):
         return
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")
 def test_memory_efficient(small_client):
     """
     We hope that we pipeline xs->ys->zs without keeping all of the xs in memory

--- a/tests/benchmarks/test_join.py
+++ b/tests/benchmarks/test_join.py
@@ -1,7 +1,7 @@
 import dask.dataframe as dd
 import pytest
 
-from ..utils_test import cluster_memory, timeseries_of_size
+from ..utils_test import cluster_memory, run_up_to_nthreads, timeseries_of_size
 
 mem_mult = [
     0.1,
@@ -16,19 +16,16 @@ mem_mult = [
 ]
 
 
+@run_up_to_nthreads("small_cluster", 40, reason="Does not finish")
 @pytest.mark.parametrize("mem_mult", mem_mult)  # [0.1, 1, 10]
 def test_join_big(small_client, mem_mult):
     memory = cluster_memory(small_client)  # 76.66 GiB
 
-    df1_big = timeseries_of_size(
-        memory * mem_mult,
-    )
+    df1_big = timeseries_of_size(memory * mem_mult)
     df1_big["x2"] = df1_big["x"] * 1e9
     df1_big = df1_big.astype({"x2": "int"})
 
-    df2_big = timeseries_of_size(
-        memory * mem_mult,
-    )
+    df2_big = timeseries_of_size(memory * mem_mult)
 
     # Control cardinality on column to join - this produces cardinality ~ to len(df)
     df2_big["x2"] = df2_big["x"] * 1e9
@@ -41,17 +38,13 @@ def test_join_big(small_client, mem_mult):
 def test_join_big_small(small_client, mem_mult):
     memory = cluster_memory(small_client)  # 76.66 GiB
 
-    df_big = timeseries_of_size(
-        memory * mem_mult,
-    )
+    df_big = timeseries_of_size(memory * mem_mult)
 
     # Control cardinality on column to join - this produces cardinality ~ to len(df)
     df_big["x2"] = df_big["x"] * 1e9
     df_big = df_big.astype({"x2": "int"})
 
-    df_small = timeseries_of_size(
-        "50 MB",
-    )  # make it obviously small
+    df_small = timeseries_of_size("50 MB")  # make it obviously small
 
     df_small["x2"] = df_small["x"] * 1e9
     df_small_pd = df_small.astype({"x2": "int"}).compute()

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -9,7 +9,9 @@ import distributed
 import fsspec
 import pandas
 import pytest
-from coiled.v2 import Cluster
+from coiled import Cluster
+
+from ..utils_test import run_up_to_nthreads
 
 
 @pytest.fixture(scope="module")
@@ -34,6 +36,7 @@ def parquet_client(parquet_cluster, cluster_kwargs, upload_cluster_dump, benchma
             yield client
 
 
+@run_up_to_nthreads("parquet_cluster", 100, reason="fixed dataset")
 def test_read_spark_generated_data(parquet_client):
     """
     Read a ~15 GB subset of a ~800 GB spark-generated
@@ -51,6 +54,7 @@ def test_read_spark_generated_data(parquet_client):
     ddf.groupby(ddf.index).first().compute()
 
 
+@run_up_to_nthreads("parquet_cluster", 50, reason="fixed dataset")
 def test_read_hive_partitioned_data(parquet_client):
     """
     Read a dataset partitioned by year and quarter.
@@ -66,6 +70,7 @@ def test_read_hive_partitioned_data(parquet_client):
     ddf.groupby(["year", "quarter"]).first().compute()
 
 
+@run_up_to_nthreads("parquet_cluster", 100, reason="fixed dataset")
 def test_write_wide_data(parquet_client, s3_url):
     # Write a ~700 partition, ~200 GB dataset with a lot of columns
     ddf = dask.datasets.timeseries(
@@ -83,6 +88,7 @@ def test_write_wide_data(parquet_client, s3_url):
     ddf.to_parquet(s3_url + "/wide-data/")
 
 
+@run_up_to_nthreads("parquet_cluster", 50, reason="fixed dataset")
 @pytest.mark.parametrize("kind", ("s3fs", "pandas", "dask"))
 def test_download_throughput(parquet_client, kind):
     # Test throughput for downloading and parsing a ~500 MB file

--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -10,7 +10,10 @@ from distributed import Client
 from packaging.version import Version
 from tornado.ioloop import PeriodicCallback
 
+from ..utils_test import run_up_to_nthreads
 
+
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 def test_trivial_workload_should_not_cause_work_stealing(small_client):
     root = delayed(lambda n: "x" * n)(utils.parse_bytes("1MiB"), dask_key_name="root")
     results = [delayed(lambda *args: None)(root, i) for i in range(10000)]
@@ -18,6 +21,7 @@ def test_trivial_workload_should_not_cause_work_stealing(small_client):
     small_client.gather(futs)
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 @pytest.mark.xfail(
     Version(distributed.__version__) < Version("2022.6.1"),
     reason="https://github.com/dask/distributed/issues/6624",
@@ -67,6 +71,7 @@ def test_work_stealing_on_scaling_up(
                 _ = future.result()
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")
 def test_work_stealing_on_inhomogeneous_workload(small_client):
     np.random.seed(42)
     delays = np.random.lognormal(1, 1.3, 500)
@@ -81,6 +86,7 @@ def test_work_stealing_on_inhomogeneous_workload(small_client):
     small_client.gather(futs)
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")
 def test_work_stealing_on_straggling_worker(
     test_name_uuid,
     upload_cluster_dump,

--- a/tests/benchmarks/test_zarr.py
+++ b/tests/benchmarks/test_zarr.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 import xarray
 
+from ..utils_test import run_up_to_nthreads
+
 
 @pytest.fixture(scope="module")
 def cmip6():
@@ -11,6 +13,7 @@ def cmip6():
     yield ds
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 def test_select_scalar(small_client, cmip6):
     ds = cmip6.isel({"lat": 20, "lon": 40, "plev": 5, "time": 1234}).compute()
     assert ds.zg.shape == ()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -435,7 +435,8 @@ def load_cluster_kwargs() -> dict:
         override_fname = os.path.join(base_dir, override_fname)
         with open(override_fname) as fh:
             override_config = yaml.safe_load(fh)
-        dask.config.update(config, override_config)
+        if override_config:
+            dask.config.update(config, override_config)
 
     default = config.pop("default")
     config = {k: dask.config.merge(default, v) for k, v in config.items()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 import uuid
+from functools import lru_cache
 
 import dask
 import distributed
@@ -451,9 +452,9 @@ def dask_env_variables():
     return {k: v for k, v in os.environ.items() if k.startswith("DASK_")}
 
 
-@pytest.fixture(scope="session")
-def cluster_kwargs() -> dict:
-    base_dir = os.path.dirname(__file__)
+@lru_cache(None)
+def load_cluster_kwargs() -> dict:
+    base_dir = os.path.join(os.path.dirname(__file__), "..")
     base_fname = os.path.join(base_dir, "cluster_kwargs.yaml")
     with open(base_fname) as fh:
         config = yaml.safe_load(fh)
@@ -474,6 +475,11 @@ def cluster_kwargs() -> dict:
         yaml.dump(config, fh)
 
     return config
+
+
+@pytest.fixture(scope="session")
+def cluster_kwargs():
+    return load_cluster_kwargs()
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,7 +464,8 @@ def load_cluster_kwargs() -> dict:
         override_fname = os.path.join(base_dir, override_fname)
         with open(override_fname) as fh:
             override_config = yaml.safe_load(fh)
-        dask.config.update(config, override_config)
+        if override_config:  # Empty files convert to None when read with yaml
+            dask.config.update(config, override_config)
 
     default = config.pop("default")
     config = {k: dask.config.merge(default, v) for k, v in config.items()}

--- a/tests/test_utils_test.py
+++ b/tests/test_utils_test.py
@@ -4,7 +4,11 @@ import pytest
 from dask.sizeof import sizeof
 from dask.utils import parse_bytes
 
-from .utils_test import scaled_array_shape, timeseries_of_size
+from .utils_test import (
+    scaled_array_shape,
+    scaled_array_shape_quadratic,
+    timeseries_of_size,
+)
 
 
 def test_scaled_array_shape():
@@ -18,6 +22,13 @@ def test_scaled_array_shape():
     assert scaled_array_shape(64, ("x", "x", "x"), dtype=float) == (2, 2, 2)
 
     assert scaled_array_shape("10kb", ("x", "1kb"), dtype=bool) == (10, 1000)
+
+
+def test_scaled_array_shape_quadratic():
+    assert scaled_array_shape("1GB", ("x",)) == (125000000,)
+    assert scaled_array_shape_quadratic("1GB", "1GB", ("x",)) == (125000000,)
+    assert scaled_array_shape_quadratic("16GB", "1GB", ("x",)) == (500000000,)
+    assert scaled_array_shape_quadratic("64MB", "1GB", ("x",)) == (31622776,)
 
 
 def sizeof_df(df):


### PR DESCRIPTION
Partially closes #483 

Review all tests so that they retain a pseudo-constant runtime as the cluster size goes up. Disable those that can't for very large clusters.

Demo with 2x[1] and 5x[2] cluster sizes:
https://github.com/coiled/coiled-runtime/actions/runs/3584320320
[1] 20 workers on small_cluster, 30 workers on parquet_cluster
[2] 50 workers on small_cluster, 75 workers on parquet_cluster