### PR TITLE
Patch release: Bump pyarrow to 10.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - fsspec ==2022.11.0
     - s3fs ==2022.11.0
     - gcsfs ==2022.11.0
-    - pyarrow ==9.0.0
+    - pyarrow ==10.0.1
     - jupyterlab ==3.5.0
     - dask-labextension ==6.0.0
     - lz4 ==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ python_requires, install_requires = get_requirements()
 
 setup(
     name="coiled-runtime",
-    version="0.2.0",
+    version="0.2.1",
     description="Simple and fast way to get started with Dask",
     url="https://github.com/coiled/coiled-runtime",
     license="BSD",


### PR DESCRIPTION
Finally, pyarrow 10.0.1 is available on conda-forge. Partially covers: #582

This PR pins pyarrow version and bumps setu.py for patch release. 

cc: @hayesgb 