### PR TITLE
Handle the case of empty cluster overrides

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -434,7 +434,8 @@ def cluster_kwargs() -> dict:
         override_fname = os.path.join(base_dir, override_fname)
         with open(override_fname) as fh:
             override_config = yaml.safe_load(fh)
-        dask.config.update(config, override_config)
+        if override_config:
+            dask.config.update(config, override_config)
 
     default = config.pop("default")
     config = {k: dask.config.merge(default, v) for k, v in config.items()}


### PR DESCRIPTION
Ran into an error like

```
    @pytest.fixture(scope="session")
    def cluster_kwargs() -> dict:
        base_dir = os.path.dirname(__file__)
        base_fname = os.path.join(base_dir, "cluster_kwargs.yaml")
        with open(base_fname) as fh:
            config = yaml.safe_load(fh)
    
        override_fname = os.getenv("CLUSTER_KWARGS")
        if override_fname:
            override_fname = os.path.join(base_dir, override_fname)
            with open(override_fname) as fh:
                override_config = yaml.safe_load(fh)
>           dask.config.update(config, override_config)

conftest.py:437: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

old = {'default': {'backend_options': {'multizone': True, 'send_prometheus_metrics': True, 'spot': True, 'spot_on_demand_fal...pes': ['m6i.large']}, 'spill_cluster': {'n_workers': 5, 'worker_disk_size': 64, 'worker_vm_types': ['m6i.large']}, ...}
new = None, priority = 'new'

    def update(old: dict, new: Mapping, priority: Literal["old", "new"] = "new") -> dict:
        """Update a nested dictionary with values from another
    
        This is like dict.update except that it smoothly merges nested values
    
        This operates in-place and modifies old
    
        Parameters
        ----------
        priority: string {'old', 'new'}
            If new (default) then the new dictionary has preference.
            Otherwise the old dictionary does.
    
        Examples
        --------
        >>> a = {'x': 1, 'y': {'a': 2}}
        >>> b = {'x': 2, 'y': {'b': 3}}
        >>> update(a, b)  # doctest: +SKIP
        {'x': 2, 'y': {'a': 2, 'b': 3}}
    
        >>> a = {'x': 1, 'y': {'a': 2}}
        >>> b = {'x': 2, 'y': {'b': 3}}
        >>> update(a, b, priority='old')  # doctest: +SKIP
        {'x': 1, 'y': {'a': 2, 'b': 3}}
    
        See Also
        --------
        dask.config.merge
        """
>       for k, v in new.items():
E       AttributeError: 'NoneType' object has no attribute 'items'
```

I suspect `safe_load` return `None` if the file is completely empty?