### PR TITLE
Switch scheduler to m6i.large (2 vCPU) from m6i.xlarge (4 vCPU)

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -14,7 +14,7 @@
 default:
   package_sync: true
   wait_for_workers: true
-  scheduler_vm_types: [m6i.xlarge]
+  scheduler_vm_types: [m6i.large]
   backend_options:
     send_prometheus_metrics: true
     spot: true


### PR DESCRIPTION
Let's use small scheduler since that doesn't appear to impact perf.

(IIRC we switched from large to xlarge back when we were using t3's, I wouldn't be surprised if it did matter for those.)