### PR TITLE
Expand coverage of join tests

### DIFF
--- a/tests/benchmarks/test_join.py
+++ b/tests/benchmarks/test_join.py
@@ -35,24 +35,30 @@ def dtypes(request, num_cols_freq):
     dtypes: dict[str, type] = {
         str(ix): float for ix in range(0, num_cols - num_str_cols)
     }
-    for ix in range(num_cols - num_str_cols, num_str_cols):
+    for ix in range(num_cols - num_str_cols, num_cols):
         dtypes[str(ix)] = str
     return dtypes
 
 
 @run_up_to_nthreads("small_cluster", 40, reason="Does not finish")
-def test_join_big(small_client, memory_multiplier, configure_shuffling, dtypes, num_cols_freq):
+def test_join_big(
+    small_client, memory_multiplier, configure_shuffling, dtypes, num_cols_freq
+):
     _, partition_freq = num_cols_freq
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df1_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes=dtypes, partition_freq=partition_freq,
+        memory * memory_multiplier,
+        dtypes=dtypes,
+        partition_freq=partition_freq,
     )  # 66.58 MiB partitions
     df1_big["predicate"] = df1_big["0"] * 1e9
     df1_big = df1_big.astype({"predicate": "int"})
 
     df2_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes=dtypes, partition_freq=partition_freq,
+        memory * memory_multiplier,
+        dtypes=dtypes,
+        partition_freq=partition_freq,
     )  # 66.58 MiB partitions
 
     # Control cardinality on column to join - this produces cardinality ~ to len(df)
@@ -64,12 +70,15 @@ def test_join_big(small_client, memory_multiplier, configure_shuffling, dtypes, 
     wait(result, small_client, 20 * 60)
 
 
-def test_join_big_small(small_client, memory_multiplier, configure_shuffling, dtypes, num_cols_freq):
+def test_join_big_small(
+    small_client, memory_multiplier, configure_shuffling, dtypes, num_cols_freq
+):
     _, partition_freq = num_cols_freq
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes=dtypes,
+        memory * memory_multiplier,
+        dtypes=dtypes,
         partition_freq=partition_freq,
     )  # 66.58 MiB partitions
 
@@ -78,7 +87,8 @@ def test_join_big_small(small_client, memory_multiplier, configure_shuffling, dt
     df_big = df_big.astype({"predicate": "int"})
 
     df_small = timeseries_of_size(
-        "100 MB", dtypes=dtypes,
+        "100 MB",
+        dtypes=dtypes,
         partition_freq=partition_freq,
     )  # make it obviously small
 
@@ -91,12 +101,15 @@ def test_join_big_small(small_client, memory_multiplier, configure_shuffling, dt
 
 
 @pytest.mark.parametrize("persist", [True, False])
-def test_set_index(small_client, persist, memory_multiplier, configure_shuffling, dtypes, num_cols_freq):
+def test_set_index(
+    small_client, persist, memory_multiplier, configure_shuffling, dtypes, num_cols_freq
+):
     _, partition_freq = num_cols_freq
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes=dtypes,
+        memory * memory_multiplier,
+        dtypes=dtypes,
         partition_freq=partition_freq,
     )  # 66.58 MiB partitions
     df_big["predicate"] = df_big["0"] * 1e9

--- a/tests/benchmarks/test_join.py
+++ b/tests/benchmarks/test_join.py
@@ -1,4 +1,7 @@
+import math
+
 import dask.dataframe as dd
+import pandas as pd
 import pytest
 
 from ..utils_test import cluster_memory, run_up_to_nthreads, timeseries_of_size, wait
@@ -9,18 +12,47 @@ def memory_multiplier(request):
     return request.param
 
 
+@pytest.fixture(params=[10, 50, 100])
+def num_cols_freq(request):
+    num_cols = request.param
+    # Rescale parition frequency such that partition size and number of
+    # partitions stay constant when varying columns
+    partition_freq = pd.to_timedelta("1d") * num_cols / 100
+    return num_cols, partition_freq
+
+
+@pytest.fixture(
+    # percentage of str cols
+    params=[
+        pytest.param(0, id="no string"),
+        pytest.param(50, id="half string"),
+        pytest.param(99, id="all string"),
+    ]
+)
+def dtypes(request, num_cols_freq):
+    num_cols, _ = num_cols_freq
+    num_str_cols = math.floor(request.param * num_cols / 100)
+    dtypes: dict[str, type] = {
+        str(ix): float for ix in range(0, num_cols - num_str_cols)
+    }
+    for ix in range(num_cols - num_str_cols, num_str_cols):
+        dtypes[str(ix)] = str
+    return dtypes
+
+
 @run_up_to_nthreads("small_cluster", 40, reason="Does not finish")
-def test_join_big(small_client, memory_multiplier, configure_shuffling):
+def test_join_big(small_client, memory_multiplier, configure_shuffling, dtypes, num_cols_freq):
+    _, partition_freq = num_cols_freq
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df1_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes={str(i): float for i in range(100)}
+        memory * memory_multiplier, dtypes=dtypes, partition_freq=partition_freq,
     )  # 66.58 MiB partitions
     df1_big["predicate"] = df1_big["0"] * 1e9
     df1_big = df1_big.astype({"predicate": "int"})
 
     df2_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes={str(i): float for i in range(100)}
+        memory * memory_multiplier, dtypes=dtypes, partition_freq=partition_freq,
     )  # 66.58 MiB partitions
 
     # Control cardinality on column to join - this produces cardinality ~ to len(df)
@@ -32,11 +64,13 @@ def test_join_big(small_client, memory_multiplier, configure_shuffling):
     wait(result, small_client, 20 * 60)
 
 
-def test_join_big_small(small_client, memory_multiplier, configure_shuffling):
+def test_join_big_small(small_client, memory_multiplier, configure_shuffling, dtypes, num_cols_freq):
+    _, partition_freq = num_cols_freq
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df_big = timeseries_of_size(
-        memory * memory_multiplier, dtypes={str(i): float for i in range(100)}
+        memory * memory_multiplier, dtypes=dtypes,
+        partition_freq=partition_freq,
     )  # 66.58 MiB partitions
 
     # Control cardinality on column to join - this produces cardinality ~ to len(df)
@@ -44,7 +78,8 @@ def test_join_big_small(small_client, memory_multiplier, configure_shuffling):
     df_big = df_big.astype({"predicate": "int"})
 
     df_small = timeseries_of_size(
-        "100 MB", dtypes={str(i): float for i in range(100)}
+        "100 MB", dtypes=dtypes,
+        partition_freq=partition_freq,
     )  # make it obviously small
 
     df_small["predicate"] = df_small["0"] * 1e9
@@ -53,3 +88,20 @@ def test_join_big_small(small_client, memory_multiplier, configure_shuffling):
     join = dd.merge(df_big, df_small_pd, on="predicate", how="inner")
     result = join.size
     wait(result, small_client, 20 * 60)
+
+
+@pytest.mark.parametrize("persist", [True, False])
+def test_set_index(small_client, persist, memory_multiplier, configure_shuffling, dtypes, num_cols_freq):
+    _, partition_freq = num_cols_freq
+    memory = cluster_memory(small_client)  # 76.66 GiB
+
+    df_big = timeseries_of_size(
+        memory * memory_multiplier, dtypes=dtypes,
+        partition_freq=partition_freq,
+    )  # 66.58 MiB partitions
+    df_big["predicate"] = df_big["0"] * 1e9
+    df_big = df_big.astype({"predicate": "int"})
+    if persist:
+        df_big = df_big.persist()
+    df_indexed = df_big.set_index("0")
+    wait(df_indexed.size, small_client, 20 * 60)


### PR DESCRIPTION
Haven't put an incredible amount of thought into these but the current benchmarks are very biased towards float / native data types and wide dataframes. This introduces parametrization over both dimensions and adds a trivial set_index benchmark

TODO: Migrations to align with current measurements