### PR TITLE
Update CI cluster tag variable name

### DIFF
--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -15,11 +15,11 @@ from ..utils_test import run_up_to_nthreads
 
 
 @pytest.fixture(scope="module")
-def parquet_cluster(dask_env_variables, cluster_kwargs, gitlab_cluster_tags):
+def parquet_cluster(dask_env_variables, cluster_kwargs, github_cluster_tags):
     with Cluster(
         f"parquet-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
-        tags=gitlab_cluster_tags,
+        tags=github_cluster_tags,
         **cluster_kwargs["parquet_cluster"],
     ) as cluster:
         yield cluster

--- a/tests/benchmarks/test_spill.py
+++ b/tests/benchmarks/test_spill.py
@@ -16,7 +16,7 @@ from ..utils_test import (
 
 
 @pytest.fixture(scope="module")
-def spill_cluster(dask_env_variables, cluster_kwargs, gitlab_cluster_tags):
+def spill_cluster(dask_env_variables, cluster_kwargs, github_cluster_tags):
     with Cluster(
         name=f"spill-{uuid.uuid4().hex[:8]}",
         environ=merge(
@@ -27,7 +27,7 @@ def spill_cluster(dask_env_variables, cluster_kwargs, gitlab_cluster_tags):
                 "DASK_DISTRIBUTED__SCHEDULER__ALLOWED_FAILURES": "0",
             },
         ),
-        tags=gitlab_cluster_tags,
+        tags=github_cluster_tags,
         **cluster_kwargs["spill_cluster"],
     ) as cluster:
         yield cluster

--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -32,12 +32,12 @@ def test_work_stealing_on_scaling_up(
     benchmark_all,
     cluster_kwargs,
     dask_env_variables,
-    gitlab_cluster_tags,
+    github_cluster_tags,
 ):
     with Cluster(
         name=test_name_uuid,
         environ=dask_env_variables,
-        tags=gitlab_cluster_tags,
+        tags=github_cluster_tags,
         **cluster_kwargs["test_work_stealing_on_scaling_up"],
     ) as cluster:
         with Client(cluster) as client:
@@ -93,13 +93,13 @@ def test_work_stealing_on_straggling_worker(
     benchmark_all,
     cluster_kwargs,
     dask_env_variables,
-    gitlab_cluster_tags,
+    github_cluster_tags,
 ):
     kwargs = cluster_kwargs["test_work_stealing_on_straggling_worker"]
     with Cluster(
         name=test_name_uuid,
         environ=dask_env_variables,
-        tags=gitlab_cluster_tags,
+        tags=github_cluster_tags,
         **kwargs,
     ) as cluster:
         with Client(cluster) as client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -399,7 +399,7 @@ def benchmark_all(
 
 
 @pytest.fixture(scope="session")
-def gitlab_cluster_tags():
+def github_cluster_tags():
     tag_names = [
         "GITHUB_JOB",
         "GITHUB_REF",
@@ -457,12 +457,12 @@ def cluster_kwargs():
 
 
 @pytest.fixture(scope="module")
-def small_cluster(request, dask_env_variables, cluster_kwargs, gitlab_cluster_tags):
+def small_cluster(request, dask_env_variables, cluster_kwargs, github_cluster_tags):
     module = os.path.basename(request.fspath).split(".")[0]
     with Cluster(
         name=f"{module}-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
-        tags=gitlab_cluster_tags,
+        tags=github_cluster_tags,
         **cluster_kwargs["small_cluster"],
     ) as cluster:
         yield cluster

--- a/tests/runtime/test_cluster_creation.py
+++ b/tests/runtime/test_cluster_creation.py
@@ -4,7 +4,7 @@ from coiled import Cluster
 
 
 def test_default_cluster_spinup_time(
-    benchmark_time, gitlab_cluster_tags, get_cluster_info
+    benchmark_time, github_cluster_tags, get_cluster_info
 ):
     """Note: this test must be kept in a separate module from the tests that use the
     small_cluster fixture (which has the scope=module) or its child small_client.
@@ -16,7 +16,7 @@ def test_default_cluster_spinup_time(
             name=f"test_default_cluster_spinup_time-{uuid.uuid4().hex[:8]}",
             n_workers=1,
             package_sync=True,
-            tags=gitlab_cluster_tags,
+            tags=github_cluster_tags,
         ) as cluster:
             with get_cluster_info(cluster):
                 pass

--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -17,12 +17,12 @@ def test_repeated_merge_spill(
     benchmark_all,
     cluster_kwargs,
     dask_env_variables,
-    gitlab_cluster_tags,
+    github_cluster_tags,
 ):
     with Cluster(
         name=f"test_repeated_merge_spill-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
-        tags=gitlab_cluster_tags,
+        tags=github_cluster_tags,
         **cluster_kwargs["test_repeated_merge_spill"],
     ) as cluster:
         with Client(cluster) as client:


### PR DESCRIPTION
Just a minor cosmetic change from `gitlab_cluster_tags` --> `github_cluster_tags`, given the tags here are all pulled from GitHub Actions environment variables