### PR TITLE
Bump xgboost to 1.7.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - tornado ==6.1
     - toolz ==0.12.0
     - zict ==2.2.0
-    - xgboost ==1.7.1
+    - xgboost ==1.7.4
     - dask-ml ==2022.5.27
     - openssl >1.1.0g
     - optuna ==3.1.0


### PR DESCRIPTION
This fixes a very tedious warning when calling `xgboost.dask.train`.