### PR TITLE
Run benchmarks with t3 instead of m6i

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -14,7 +14,7 @@
 default:
   package_sync: true
   wait_for_workers: true
-  scheduler_vm_types: [m6i.large]
+  scheduler_vm_types: [t3.large]
   backend_options:
     send_prometheus_metrics: true
     spot: true
@@ -24,7 +24,7 @@ default:
 # For all tests using the small_client fixture
 small_cluster:
   n_workers: 10
-  worker_vm_types: [m6i.large]  # 2CPU, 8GiB
+  worker_vm_types: [t3.large]  # 2CPU, 8GiB
 
 # For test_parquet.py
 parquet_cluster:
@@ -35,7 +35,7 @@ parquet_cluster:
 spill_cluster:
   n_workers: 5
   worker_disk_size: 64
-  worker_vm_types: [m6i.large]  # 2CPU, 8GiB
+  worker_vm_types: [t3.large]  # 2CPU, 8GiB
 
 # Specific tests
 test_work_stealing_on_scaling_up:
@@ -48,4 +48,4 @@ test_work_stealing_on_straggling_worker:
 
 test_repeated_merge_spill:
   n_workers: 20
-  worker_vm_types: [m6i.large]
+  worker_vm_types: [t3.large]


### PR DESCRIPTION
I'd like a new run with t3 instances so I can screenshot a comparison of the costs in Cost Explorer, etc.