### PR TITLE
Switch Coiled account to one specifically for benchmarks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def get_coiled_runtime_version():
             return "unknown"
 
 
-dask.config.set({"coiled.account": "dask-engineering"})
+dask.config.set({"coiled.account": "dask-benchmarks"})
 
 COILED_RUNTIME_VERSION = get_coiled_runtime_version()
 COILED_SOFTWARE_NAME = "package_sync"


### PR DESCRIPTION
Using a designated Coiled account for CI benchmarking will make permission boundary easier so we can make more of the benchmarking metrics public.