### PR TITLE
Don't test against 0.2.1 runtime release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -252,7 +252,7 @@ jobs:
           environment-file: ci/environment-dashboard.yml
 
       - name: Generate dashboards
-        # Show differences of upstream vs. latest unpublished
+        # Show differences of upstream vs. latest
         run: python dashboard.py -d benchmark.db -o static -b coiled-latest-py3.9
 
       - name: Upload artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9"]
         pytest_args: [tests]
-        runtime-version: [upstream, latest, "0.2.1"]
+        runtime-version: [upstream, latest]
         include:
           # Run stability tests on Python 3.8
           - pytest_args: tests/stability
@@ -43,10 +43,6 @@ jobs:
             python-version: "3.8"
             runtime-version: latest
             os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.8"
-            runtime-version: "0.2.1"
-            os: ubuntu-latest
           # Run stability tests on Python 3.10
           - pytest_args: tests/stability
             python-version: "3.10"
@@ -55,10 +51,6 @@ jobs:
           - pytest_args: tests/stability
             python-version: "3.10"
             runtime-version: latest
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.10"
-            runtime-version: "0.2.1"
             os: ubuntu-latest
           # Run stability tests on Python Windows and MacOS (latest py39 only)
           - pytest_args: tests/stability
@@ -260,8 +252,8 @@ jobs:
           environment-file: ci/environment-dashboard.yml
 
       - name: Generate dashboards
-        # Show differences of upstream vs. latest unpublished vs. latest publshed
-        run: python dashboard.py -d benchmark.db -o static -b coiled-latest-py3.9 coiled-0.2.1-py3.9
+        # Show differences of upstream vs. latest unpublished
+        run: python dashboard.py -d benchmark.db -o static -b coiled-latest-py3.9
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This is an incremental change related to https://github.com/coiled/coiled-runtime/issues/732