### PR TITLE
Fix failure in 'pip installation' CI every time there's a new release

### DIFF
--- a/tests/runtime/test_build.py
+++ b/tests/runtime/test_build.py
@@ -103,16 +103,24 @@ def test_install_dist():
 @pytest.mark.latest_runtime
 def test_latest_coiled():
     # Ensure `coiled-runtime` installs the latest version of `coiled` by default
+    # This is installed from either conda-forge or pip, depending on which github action
+    # is running this test
     v_installed = Version(coiled.__version__)
 
     # Get latest `coiled` release version from conda-forge
     output = subprocess.check_output(
-        shlex.split("conda search --override-channels --json -c conda-forge coiled")
+        shlex.split("conda search --override-channels --json -c conda-forge")
     )
     result = json.loads(output)
     v_latest = Version(result["coiled"][-1]["version"])
-
-    assert v_installed == v_latest
+    # conda can lag behind a few days from pip; allow for the next version too
+    v_allowed = {
+        v_latest,
+        Version(f"{v_latest.major}.{v_latest.minor}.{v_latest.micro + 1}"),
+        Version(f"{v_latest.major}.{v_latest.minor + 1}.0"),
+        Version(f"{v_latest.major + 1}.0.0"),
+    }
+    assert v_installed in v_allowed
 
 
 def test_version_warning_packages():

--- a/tests/runtime/test_build.py
+++ b/tests/runtime/test_build.py
@@ -109,7 +109,7 @@ def test_latest_coiled():
 
     # Get latest `coiled` release version from conda-forge
     output = subprocess.check_output(
-        shlex.split("conda search --override-channels --json -c conda-forge")
+        shlex.split("conda search --override-channels --json -c conda-forge coiled")
     )
     result = json.loads(output)
     v_latest = Version(result["coiled"][-1]["version"])


### PR DESCRIPTION
Fix e.g.
https://github.com/coiled/coiled-runtime/actions/runs/4617936173/jobs/8164769127?pr=746
AssertionError: assert <Version('0.5.10')> == <Version('0.5.9')>