### PR TITLE
Add button to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
   schedule:
     # Runs "At 00:01" (see https://crontab.guru)
     - cron: "1 0 * * *"
+  workflow_dispatch:
 
 concurrency:
   # Include `github.event_name` to avoid pushes to `main` and


### PR DESCRIPTION
This makes it more convenient to run tests against the `main` branch of this repo. Currently my approach is to open a PR with an empty commit like https://github.com/coiled/coiled-runtime/pull/776