### PR TITLE
DOC: add link(s) to blog(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Set of Dask benchmarks run daily at scale in Coiled Clusters.
 
 ## Blogs
 
-Some these benchmarks have been published in blogs. These are the best source for viewing results:
+Some of these benchmarks have been published in blogs. These are the best source for viewing results:
 
  - [DataFrames at Scale Comparison: TPC-H](https://docs.coiled.io/blog/tpch.html)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Set of Dask benchmarks run daily at scale in Coiled Clusters.
 
+## Blogs
+
+Some these benchmarks have been published in blogs. These are the best source for viewing results:
+
+ - [DataFrames at Scale Comparison: TPC-H](https://docs.coiled.io/blog/tpch.html)
+
 ## Test Locally (for developers)
 
 The `coiled benchmarks` test suite can be run locally with the following steps:


### PR DESCRIPTION
I find it helpful to flesh out the README and a link to the blogs that exist that use data/results from this repo. That way there are two ways links e.g. https://docs.coiled.io/blog/tpch.html has a link to https://github.com/coiled/benchmarks and vice versa.

I wasn't sure wherever to add the blogs section and the top of the README or at the bottom. I opted for the top.