### PR TITLE
Don't parallelize geospatial benchmarks

### DIFF
--- a/.github/workflows/geospatial.yml
+++ b/.github/workflows/geospatial.yml
@@ -69,7 +69,6 @@ jobs:
       run: |
         pytest --benchmark \
             tests/geospatial -m geo_execution \
-            -n 4 --dist loadscope \
             --scale ${{ inputs.scale }} \
 
     - name: Upload benchmark results


### PR DESCRIPTION
I've run into CPU limits when running multiple tests on `medium` scale in parallel, so let's avoid running benchmarks simultaneously for now.