### PR TITLE
Run geospatial benchmarks using on-demand clusters

### DIFF
--- a/tests/geospatial/conftest.py
+++ b/tests/geospatial/conftest.py
@@ -192,6 +192,7 @@ def setup_benchmark(
             name=cluster_name,
             tags=github_cluster_tags,
             n_workers=n_workers,
+            spot_policy="on-demand",
             **cluster_kwargs,
         ) as cluster:
             if env:


### PR DESCRIPTION
Spot replacement severely skews benchmark results, and we currently don't have the ability to detect replacement and exclude affected results or restart benchmarks (#1241).

cc @fjetter: This may have a significant impact on cost.