### PR TITLE
Auto-chunking for ERA5 loading

### DIFF
--- a/tests/geospatial/workloads/atmospheric_circulation.py
+++ b/tests/geospatial/workloads/atmospheric_circulation.py
@@ -11,7 +11,7 @@ def atmospheric_circulation(
 ) -> Delayed:
     ds = xr.open_zarr(
         "gs://weatherbench2/datasets/era5/1959-2023_01_10-full_37-1h-0p25deg-chunk-1.zarr",
-        chunks={},
+        chunks={"time": "auto"},
     )
     if scale == "small":
         # 852.56 GiB (small)

--- a/tests/geospatial/workloads/climatology.py
+++ b/tests/geospatial/workloads/climatology.py
@@ -72,6 +72,7 @@ def rechunk_map_blocks(
     # Load dataset
     ds = xr.open_zarr(
         "gs://weatherbench2/datasets/era5/1959-2023_01_10-wb13-6h-1440x721.zarr",
+        chunks={"time": "auto"},
     )
 
     if scale == "small":
@@ -122,6 +123,7 @@ def highlevel_api(
     # Load dataset
     ds = xr.open_zarr(
         "gs://weatherbench2/datasets/era5/1959-2023_01_10-wb13-6h-1440x721.zarr",
+        chunks={"time": "auto"},
     )
 
     if scale == "small":

--- a/tests/geospatial/workloads/rechunking.py
+++ b/tests/geospatial/workloads/rechunking.py
@@ -11,6 +11,7 @@ def era5_rechunking(
 ) -> Delayed:
     ds = xr.open_zarr(
         "gs://weatherbench2/datasets/era5/1959-2023_01_10-full_37-1h-0p25deg-chunk-1.zarr",
+        chunks={"time": "auto"},
     ).drop_encoding()
 
     if scale == "small":

--- a/tests/geospatial/workloads/regridding.py
+++ b/tests/geospatial/workloads/regridding.py
@@ -13,6 +13,7 @@ def xesmf(
 ) -> Delayed:
     ds = xr.open_zarr(
         "gs://weatherbench2/datasets/era5/1959-2023_01_10-full_37-1h-0p25deg-chunk-1.zarr",
+        chunks={"time": "auto"},
     )
     # Fixed time range and variable as the interesting part of this benchmark scales with the
     # regridding matrix


### PR DESCRIPTION
This PR defaults to using `auto` chunks along the time dimension when loading the ERA5 dataset in geospatial benchmarks. Due to the small size of native inputs (4 MiB), this results in smaller graphs and (mostly) runtime improvements. Here are the runtimes for the small scale:

![auto-chunking](https://github.com/user-attachments/assets/c7befc89-ce33-43ed-a94f-c1a5becbc3f2)


The performance regression on `test_highlevel_api` is curious and should be investigated. Unfortunately, we do not measure task graph sizes, so I can't provide any numbers here.

